### PR TITLE
Move String Resources

### DIFF
--- a/GSoC_REPORT.md
+++ b/GSoC_REPORT.md
@@ -4,7 +4,10 @@
 **Mentor(s)**: Wolfgang Slany, Paul Spiesberger  
 **Organization**: International Catrobat Association  
 **Project**: AI Tutor for Pocket Code Students  
-**GitHub Repository**: https://github.com/Catrobat/catrobat-ai-tutor
+**GitHub Repository**:
+- https://github.com/Catrobat/catrobat-ai-tutor
+- https://github.com/Catrobat/catrobat-ai-tutor-ktxpy-editor
+- https://github.com/Catrobat/catrobat-ai-tutor-js-editor
 
 ---
 
@@ -35,11 +38,11 @@ This design empowers users by:
 
 - The KMP library is functional for Android.
 - The PoC app demonstrates:
-    - Detecting installed AI apps.
-    - Constructing prompts.
-    - Sending prompts to AI apps via Intents.
-    - Copy-paste fallback mechanism.
-    - Tutorial/Help UI.
+  - Detecting installed AI apps.
+  - Constructing prompts.
+  - Sending prompts to AI apps via Intents.
+  - Copy-paste fallback mechanism.
+  - Tutorial/Help UI.
 - Initial preparation for publishing the library to Maven Central.
 
 ---
@@ -55,7 +58,7 @@ This design empowers users by:
 
 ## 5. Code Contributions
 
-All work was pushed to the [Catrobat AI Tutor repository](https://github.com/Catrobat/catrobat-ai-tutor) and the [PoC AI Tutor](https://github.com/Catrobat/catrobat-ai-tutor-ktxpy-editor).  
+All work was pushed to the [Catrobat AI Tutor repository](https://github.com/Catrobat/catrobat-ai-tutor), the [PoC AI Tutor (Python)](https://github.com/Catrobat/catrobat-ai-tutor-ktxpy-editor), and the [PoC AI Tutor (JavaScript)](https://github.com/Catrobat/catrobat-ai-tutor-js-editor).  
 Pull requests include:
 - Add local Maven publishing setup ([PR link](https://github.com/Catrobat/catrobat-ai-tutor/pull/1)).
 - AI App Intent Bridge and UI ([PR link](https://github.com/Catrobat/catrobat-ai-tutor/pull/5)).

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -142,7 +142,7 @@ mavenPublishing {
             }
             developer {
                 id = "spipau"
-                name = " Paul Spiesberger"
+                name = "Paul Spiesberger"
                 url = "https://github.com/spipau"
             }
         }

--- a/shared/src/androidMain/kotlin/org/catrobat/aitutor/ui/AiAppLauncher.kt
+++ b/shared/src/androidMain/kotlin/org/catrobat/aitutor/ui/AiAppLauncher.kt
@@ -13,7 +13,7 @@ import org.catrobat.shared.generated.resources.send_prompt_with
 import org.jetbrains.compose.resources.getString
 
 actual class AiAppLauncher(private val context: Context) {
-    actual fun launchApp(
+    actual suspend fun launchApp(
         prompt: String,
         packageName: String?,
     ) {
@@ -47,20 +47,20 @@ actual class AiAppLauncher(private val context: Context) {
                     // You should probably copy the prompt to the clipboard here as well.
                     Toast.makeText(
                         context,
-                        runBlocking { getString(Res.string.could_not_send_prompt_directly) },
+                        getString(Res.string.could_not_send_prompt_directly),
                         Toast.LENGTH_LONG,
                     ).show()
                 } else {
                     Toast.makeText(
                         context,
-                        runBlocking { getString(Res.string.could_not_launch_this_app) },
+                        getString(Res.string.could_not_launch_this_app),
                         Toast.LENGTH_SHORT,
                     ).show()
                 }
             } else {
                 Toast.makeText(
                     context,
-                    runBlocking { getString(Res.string.no_app_found_to_handle_this_action) },
+                    getString(Res.string.no_app_found_to_handle_this_action),
                     Toast.LENGTH_SHORT,
                 ).show()
             }

--- a/shared/src/androidMain/kotlin/org/catrobat/aitutor/ui/AiAppLauncher.kt
+++ b/shared/src/androidMain/kotlin/org/catrobat/aitutor/ui/AiAppLauncher.kt
@@ -4,6 +4,13 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
+import kotlinx.coroutines.runBlocking
+import org.catrobat.shared.generated.resources.Res
+import org.catrobat.shared.generated.resources.could_not_launch_this_app
+import org.catrobat.shared.generated.resources.could_not_send_prompt_directly
+import org.catrobat.shared.generated.resources.no_app_found_to_handle_this_action
+import org.catrobat.shared.generated.resources.send_prompt_with
+import org.jetbrains.compose.resources.getString
 
 actual class AiAppLauncher(private val context: Context) {
     actual fun launchApp(
@@ -24,7 +31,8 @@ actual class AiAppLauncher(private val context: Context) {
             // Use a chooser if no specific package is set (for the "More" option)
             val chooserIntent =
                 if (packageName == null) {
-                    Intent.createChooser(sendIntent, "Send prompt with...")
+                    val chooserTitle = runBlocking { getString(Res.string.send_prompt_with) }
+                    Intent.createChooser(sendIntent, chooserTitle)
                 } else {
                     sendIntent
                 }
@@ -39,15 +47,22 @@ actual class AiAppLauncher(private val context: Context) {
                     // You should probably copy the prompt to the clipboard here as well.
                     Toast.makeText(
                         context,
-                        "Couldn't send prompt directly. Please paste it manually.",
+                        runBlocking { getString(Res.string.could_not_send_prompt_directly) },
                         Toast.LENGTH_LONG,
                     ).show()
                 } else {
-                    Toast.makeText(context, "Could not launch this app.", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(
+                        context,
+                        runBlocking { getString(Res.string.could_not_launch_this_app) },
+                        Toast.LENGTH_SHORT,
+                    ).show()
                 }
             } else {
-                Toast.makeText(context, "No app found to handle this action.", Toast.LENGTH_SHORT)
-                    .show()
+                Toast.makeText(
+                    context,
+                    runBlocking { getString(Res.string.no_app_found_to_handle_this_action) },
+                    Toast.LENGTH_SHORT,
+                ).show()
             }
         }
     }

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -38,7 +38,6 @@
     <string name="choose_ai_app_of_your_choice">Choose AI App of your choice</string>
 
     <!--    About Screen-->
-    <string name="about_app">About App</string>
     <string name="version">Version %1$s</string>
     <string name="developers">Developers</string>
     <string name="source_code">Source Code</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -1,4 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="catrobat_ai_tutor">Catrobat AI Tutor</string>
+
+    <!--    Common Strings-->
     <string name="close">Close</string>
+    <string name="more">More</string>
+    <string name="about">About</string>
+    <string name="cancel">Cancel</string>
+    <string name="send">Send</string>
+
+    <!--    Content Description-->
+    <string name="ask_ai_tutor">Ask AI Tutor</string>
+    <string name="share_with_other_apps">Share with other apps</string>
+    <string name="show_tutorial">Show Tutorial</string>
+
+    <!--    Input View-->
+    <string name="include_code_context">Include code context</string>
+    <string name="include_code_output">Include code output</string>
+    <string name="prompt_version_debug">Prompt Version (Debug)</string>
+    <string name="type_your_question_here">Type your question here...</string>
+
+    <!--    Tutorial View-->
+    <string name="tutorial_header">Welcome to the AI Tutor!</string>
+    <string name="tutorial_step_1">1. Ask Your Question</string>
+    <string name="tutorial_step_1_description">Type your question. You can also include your current code for better context.</string>
+    <string name="tutorial_step_2">2. Choose Your AI</string>
+    <string name="tutorial_step_2_description">Select your favorite AI app (like Gemini or ChatGPT) from the list of installed apps.</string>
+    <string name="tutorial_step_3">3. Launch and Learn</string>
+    <string name="tutorial_step_3_description">We'll prepare a special prompt and launch the AI app for you to get the answer.</string>
+    <string name="tutorial_step_4">4. Copy &amp; Paste</string>
+    <string name="tutorial_step_4_description">Copy the code solution from the AI app, then return here to paste it into your project.</string>
+    <string name="skip">Skip</string>
+    <string name="got_it">Got It!</string>
+    <string name="next">Next</string>
+
+    <!--    App Chooser View-->
+    <string name="choose_ai_app_of_your_choice">Choose AI App of your choice</string>
+
+    <!--    About Screen-->
+    <string name="about_app">About App</string>
+    <string name="version">Version %1$s</string>
+    <string name="developers">Developers</string>
+    <string name="source_code">Source Code</string>
+    <string name="open_source_libraries">Open Source Libraries</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="developers">Developers</string>
     <string name="source_code">Source Code</string>
     <string name="open_source_libraries">Open Source Libraries</string>
+    <string name="content_description_logo_catrobat">The logo of Catrobat: a cat with bat wings</string>
 
     <!--    AiAppLauncher-->
     <string name="send_prompt_with">Send prompt with...</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -42,4 +42,13 @@
     <string name="developers">Developers</string>
     <string name="source_code">Source Code</string>
     <string name="open_source_libraries">Open Source Libraries</string>
+
+    <!--    AiAppLauncher-->
+    <string name="send_prompt_with">Send prompt with...</string>
+    <string name="could_not_send_prompt_directly">Couldn't send prompt directly. Please paste it manually.</string>
+    <string name="could_not_launch_this_app">Could not launch this app.</string>
+    <string name="no_app_found_to_handle_this_action">No app found to handle this action.</string>
+
+    <!--    AiTutorViewModel-->
+    <string name="error_loading_installed_ai_apps">Failed to load installed AI apps: %1$s</string>
 </resources>

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/AiAppLauncher.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/AiAppLauncher.kt
@@ -1,7 +1,7 @@
 package org.catrobat.aitutor.ui
 
 expect class AiAppLauncher {
-    fun launchApp(
+    suspend fun launchApp(
         prompt: String,
         packageName: String? = null,
     )

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AboutScreen.kt
@@ -47,7 +47,6 @@ import com.mikepenz.aboutlibraries.ui.compose.m3.libraryColors
 import com.mikepenz.aboutlibraries.ui.compose.rememberLibraries
 import org.catrobat.aitutor.ui.theme.AiTutorColors
 import org.catrobat.shared.generated.resources.Res
-import org.catrobat.shared.generated.resources.about
 import org.catrobat.shared.generated.resources.catrobat_ai_tutor
 import org.catrobat.shared.generated.resources.close
 import org.catrobat.shared.generated.resources.developers

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AboutScreen.kt
@@ -47,8 +47,14 @@ import com.mikepenz.aboutlibraries.ui.compose.m3.libraryColors
 import com.mikepenz.aboutlibraries.ui.compose.rememberLibraries
 import org.catrobat.aitutor.ui.theme.AiTutorColors
 import org.catrobat.shared.generated.resources.Res
+import org.catrobat.shared.generated.resources.about
+import org.catrobat.shared.generated.resources.catrobat_ai_tutor
 import org.catrobat.shared.generated.resources.close
+import org.catrobat.shared.generated.resources.developers
 import org.catrobat.shared.generated.resources.logo_catrobat
+import org.catrobat.shared.generated.resources.open_source_libraries
+import org.catrobat.shared.generated.resources.source_code
+import org.catrobat.shared.generated.resources.version
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -119,7 +125,7 @@ internal fun AboutScreen(onDismissRequest: () -> Unit) {
                         ) {
                             Image(
                                 painter = painterResource(Res.drawable.logo_catrobat),
-                                contentDescription = "About",
+                                contentDescription = stringResource(Res.string.about),
                                 modifier =
                                     Modifier
                                         .size(64.dp)
@@ -127,14 +133,14 @@ internal fun AboutScreen(onDismissRequest: () -> Unit) {
                             )
                             Spacer(Modifier.height(16.dp))
                             Text(
-                                text = "Catrobat AI Tutor",
+                                text = stringResource(Res.string.catrobat_ai_tutor),
                                 fontSize = 22.sp,
                                 fontWeight = FontWeight.Bold,
                                 color = AiTutorColors.onSurface,
                             )
                             Spacer(Modifier.height(4.dp))
                             Text(
-                                text = "Version 0.0.1",
+                                text = stringResource(Res.string.version, "0.0.1"),
                                 fontSize = 16.sp,
                                 color = AiTutorColors.onSurfaceVariant,
                             )
@@ -144,7 +150,7 @@ internal fun AboutScreen(onDismissRequest: () -> Unit) {
 
                     // Developers Section
                     item {
-                        SectionHeader(title = "Developers")
+                        SectionHeader(title = stringResource(Res.string.developers))
                     }
                     item {
                         DeveloperInfoCard(
@@ -164,7 +170,7 @@ internal fun AboutScreen(onDismissRequest: () -> Unit) {
                     // Source Code Section
                     item {
                         Spacer(Modifier.height(16.dp))
-                        SectionHeader(title = "Source Code")
+                        SectionHeader(title = stringResource(Res.string.source_code))
                         LinkCard(
                             "GitHub Repository",
                             "https://github.com/Catrobat/catrobat-ai-tutor",
@@ -175,7 +181,7 @@ internal fun AboutScreen(onDismissRequest: () -> Unit) {
 
                     // Header for the actual libraries list
                     item {
-                        SectionHeader(title = "Open Source Libraries")
+                        SectionHeader(title = stringResource(Res.string.open_source_libraries))
                         Spacer(Modifier.height(8.dp))
                     }
                 },

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AboutScreen.kt
@@ -125,7 +125,7 @@ internal fun AboutScreen(onDismissRequest: () -> Unit) {
                         ) {
                             Image(
                                 painter = painterResource(Res.drawable.logo_catrobat),
-                                contentDescription = stringResource(Res.string.about),
+                                contentDescription = null,
                                 modifier =
                                     Modifier
                                         .size(64.dp)

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AboutScreen.kt
@@ -49,6 +49,7 @@ import org.catrobat.aitutor.ui.theme.AiTutorColors
 import org.catrobat.shared.generated.resources.Res
 import org.catrobat.shared.generated.resources.catrobat_ai_tutor
 import org.catrobat.shared.generated.resources.close
+import org.catrobat.shared.generated.resources.content_description_logo_catrobat
 import org.catrobat.shared.generated.resources.developers
 import org.catrobat.shared.generated.resources.logo_catrobat
 import org.catrobat.shared.generated.resources.open_source_libraries
@@ -124,7 +125,7 @@ internal fun AboutScreen(onDismissRequest: () -> Unit) {
                         ) {
                             Image(
                                 painter = painterResource(Res.drawable.logo_catrobat),
-                                contentDescription = null,
+                                contentDescription = stringResource(Res.string.content_description_logo_catrobat),
                                 modifier =
                                     Modifier
                                         .size(64.dp)

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AiAppChip.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AiAppChip.kt
@@ -1,5 +1,3 @@
-// shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AiAppChip.kt
-
 package org.catrobat.aitutor.ui.components
 
 import androidx.compose.foundation.Image

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AppChooserView.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AppChooserView.kt
@@ -23,6 +23,9 @@ import androidx.compose.ui.window.DialogProperties
 import org.catrobat.aitutor.ui.theme.AiTutorColors
 import org.catrobat.aitutor.ui.viewmodel.AiTutorUiState
 import org.catrobat.aitutor.util.platformImagePainter
+import org.catrobat.shared.generated.resources.Res
+import org.catrobat.shared.generated.resources.choose_ai_app_of_your_choice
+import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -51,7 +54,7 @@ internal fun AppChooserView(
             ) {
                 Column(modifier = Modifier.padding(16.dp)) {
                     Text(
-                        text = "Choose AI App of your choice",
+                        text = stringResource(Res.string.choose_ai_app_of_your_choice),
                         style = MaterialTheme.typography.titleMedium,
                         color = AiTutorColors.onSurface,
                         modifier = Modifier.padding(bottom = 16.dp),

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/InputView.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/InputView.kt
@@ -48,6 +48,16 @@ import androidx.compose.ui.window.DialogProperties
 import org.catrobat.aitutor.domain.prompt.PromptVersion
 import org.catrobat.aitutor.ui.theme.AiTutorColors
 import org.catrobat.aitutor.util.isDebug
+import org.catrobat.shared.generated.resources.Res
+import org.catrobat.shared.generated.resources.about
+import org.catrobat.shared.generated.resources.cancel
+import org.catrobat.shared.generated.resources.include_code_context
+import org.catrobat.shared.generated.resources.include_code_output
+import org.catrobat.shared.generated.resources.prompt_version_debug
+import org.catrobat.shared.generated.resources.send
+import org.catrobat.shared.generated.resources.show_tutorial
+import org.catrobat.shared.generated.resources.type_your_question_here
+import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -86,7 +96,7 @@ internal fun InputView(
             ) {
                 Column(modifier = Modifier.padding(16.dp)) {
                     ContextSwitchRow(
-                        text = "Include code context",
+                        text = stringResource(Res.string.include_code_context),
                         checked = isCodeContextIncluded,
                         onCheckedChange = onToggleCodeContext,
                     )
@@ -94,7 +104,7 @@ internal fun InputView(
                     // Output Context (Conditionally present)
                     if (isOutputContextIncluded != null) {
                         ContextSwitchRow(
-                            text = "Include code output",
+                            text = stringResource(Res.string.include_code_output),
                             checked = isOutputContextIncluded,
                             onCheckedChange = onToggleOutputContext,
                         )
@@ -116,7 +126,7 @@ internal fun InputView(
                                 readOnly = true,
                                 value = selectedPromptVersion.displayName,
                                 onValueChange = {},
-                                label = { Text("Prompt Version (Debug)") },
+                                label = { Text(text = stringResource(Res.string.prompt_version_debug)) },
                                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
                                 colors =
                                     TextFieldDefaults.colors().copy(
@@ -166,13 +176,13 @@ internal fun InputView(
                         modifier = Modifier.fillMaxWidth(),
                         placeholder = {
                             Text(
-                                "Type your question here...",
+                                text = stringResource(Res.string.type_your_question_here),
                                 color = AiTutorColors.onSurfaceVariant,
                             )
                         },
                         leadingIcon = {
                             Icon(
-                                Icons.Default.AutoAwesome,
+                                imageVector = Icons.Default.AutoAwesome,
                                 contentDescription = null,
                                 tint = AiTutorColors.onSurfaceVariant,
                             )
@@ -209,21 +219,24 @@ internal fun InputView(
                             IconButton(onClick = onAboutRequest) {
                                 Icon(
                                     imageVector = Icons.Outlined.Info,
-                                    contentDescription = "About",
+                                    contentDescription = stringResource(Res.string.about),
                                     tint = AiTutorColors.onSurfaceVariant,
                                 )
                             }
                             IconButton(onClick = onHelpRequest) {
                                 Icon(
                                     imageVector = Icons.AutoMirrored.Filled.HelpOutline,
-                                    contentDescription = "Show Tutorial",
+                                    contentDescription = stringResource(Res.string.show_tutorial),
                                     tint = AiTutorColors.onSurfaceVariant,
                                 )
                             }
                         }
 
                         TextButton(onClick = onDismissRequest) {
-                            Text("Cancel", color = AiTutorColors.onSurfaceVariant)
+                            Text(
+                                text = stringResource(Res.string.cancel),
+                                color = AiTutorColors.onSurfaceVariant,
+                            )
                         }
                         Spacer(Modifier.width(8.dp))
                         Button(
@@ -245,7 +258,7 @@ internal fun InputView(
                         ) {
                             Icon(
                                 imageVector = Icons.AutoMirrored.Filled.Send,
-                                contentDescription = "Send",
+                                contentDescription = stringResource(Res.string.send),
                             )
                         }
                     }

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/MoreChip.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/MoreChip.kt
@@ -21,6 +21,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import org.catrobat.aitutor.ui.theme.AiTutorColors
+import org.catrobat.shared.generated.resources.Res
+import org.catrobat.shared.generated.resources.more
+import org.catrobat.shared.generated.resources.share_with_other_apps
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun MoreChip(onClick: () -> Unit) {
@@ -43,7 +47,7 @@ fun MoreChip(onClick: () -> Unit) {
         ) {
             Icon(
                 imageVector = Icons.Default.MoreHoriz,
-                contentDescription = "Share with other apps",
+                contentDescription = stringResource(Res.string.share_with_other_apps),
                 tint = AiTutorColors.onSurfaceVariant,
                 modifier = Modifier.fillMaxSize(),
             )
@@ -51,7 +55,7 @@ fun MoreChip(onClick: () -> Unit) {
 
         Spacer(Modifier.height(8.dp))
         Text(
-            "More",
+            text = stringResource(Res.string.more),
             style = MaterialTheme.typography.labelSmall,
             color = AiTutorColors.onSurfaceVariant,
         )

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/TutorialView.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/TutorialView.kt
@@ -44,37 +44,51 @@ import org.catrobat.shared.generated.resources.Res
 import org.catrobat.shared.generated.resources.ask_your_question
 import org.catrobat.shared.generated.resources.choose_your_ai
 import org.catrobat.shared.generated.resources.copy_and_paste
+import org.catrobat.shared.generated.resources.got_it
 import org.catrobat.shared.generated.resources.launch_and_learn
+import org.catrobat.shared.generated.resources.next
+import org.catrobat.shared.generated.resources.skip
+import org.catrobat.shared.generated.resources.tutorial_header
+import org.catrobat.shared.generated.resources.tutorial_step_1
+import org.catrobat.shared.generated.resources.tutorial_step_1_description
+import org.catrobat.shared.generated.resources.tutorial_step_2
+import org.catrobat.shared.generated.resources.tutorial_step_2_description
+import org.catrobat.shared.generated.resources.tutorial_step_3
+import org.catrobat.shared.generated.resources.tutorial_step_3_description
+import org.catrobat.shared.generated.resources.tutorial_step_4
+import org.catrobat.shared.generated.resources.tutorial_step_4_description
 import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
 
 private data class TutorialPageData(
     val imageResource: DrawableResource,
-    val title: String,
-    val description: String,
+    val title: StringResource,
+    val description: StringResource,
 )
 
 private val tutorialPages =
     listOf(
         TutorialPageData(
             imageResource = Res.drawable.ask_your_question,
-            title = "1. Ask Your Question",
-            description = "Type your question. You can also include your current code for better context.",
+            title = Res.string.tutorial_step_1,
+            description = Res.string.tutorial_step_1_description,
         ),
         TutorialPageData(
             imageResource = Res.drawable.choose_your_ai,
-            title = "2. Choose Your AI",
-            description = "Select your favorite AI app (like Gemini or ChatGPT) from the list of installed apps.",
+            title = Res.string.tutorial_step_2,
+            description = Res.string.tutorial_step_2_description,
         ),
         TutorialPageData(
             imageResource = Res.drawable.launch_and_learn,
-            title = "3. Launch and Learn",
-            description = "We'll prepare a special prompt and launch the AI app for you to get the answer.",
+            title = Res.string.tutorial_step_3,
+            description = Res.string.tutorial_step_3_description,
         ),
         TutorialPageData(
             imageResource = Res.drawable.copy_and_paste,
-            title = "4. Copy & Paste",
-            description = "Copy the code solution from the AI app, then return here to paste it into your project.",
+            title = Res.string.tutorial_step_4,
+            description = Res.string.tutorial_step_4_description,
         ),
     )
 
@@ -114,7 +128,7 @@ private fun TutorialPagerContent(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
-            text = "Welcome to the AI Tutor!",
+            text = stringResource(Res.string.tutorial_header),
             style = MaterialTheme.typography.headlineSmall,
             color = AiTutorColors.onSurface,
             fontWeight = FontWeight.Bold,
@@ -162,7 +176,7 @@ private fun TutorialPage(data: TutorialPageData) {
             contentScale = ContentScale.Fit,
         )
         Text(
-            text = data.title,
+            text = stringResource(data.title),
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
             color = AiTutorColors.onSurface,
@@ -170,7 +184,7 @@ private fun TutorialPage(data: TutorialPageData) {
         )
         Spacer(Modifier.height(8.dp))
         Text(
-            text = data.description,
+            text = stringResource(data.description),
             style = MaterialTheme.typography.bodyMedium,
             color = AiTutorColors.onSurfaceVariant,
             textAlign = TextAlign.Center,
@@ -227,7 +241,7 @@ private fun PagerButtons(
             Spacer(modifier = Modifier.width(1.dp)) // To balance the Row
         } else {
             TextButton(onClick = onDone) {
-                Text("Skip", color = AiTutorColors.primary)
+                Text(text = stringResource(Res.string.skip), color = AiTutorColors.primary)
             }
         }
 
@@ -237,7 +251,7 @@ private fun PagerButtons(
             colors = ButtonDefaults.buttonColors(containerColor = AiTutorColors.primary),
         ) {
             Text(
-                text = if (isLastPage) "Got It!" else "Next",
+                text = stringResource(if (isLastPage) Res.string.got_it else Res.string.next),
                 color = AiTutorColors.onPrimary,
             )
         }

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/public/AiTutorFloatingActionButton.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/public/AiTutorFloatingActionButton.kt
@@ -10,6 +10,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.catrobat.aitutor.ui.theme.AiTutorColors
+import org.catrobat.shared.generated.resources.Res
+import org.catrobat.shared.generated.resources.ask_ai_tutor
+import org.jetbrains.compose.resources.stringResource
 
 /**
  * A pre-styled `FloatingActionButton` (FAB) designed to launch the AI Tutor.
@@ -57,6 +60,9 @@ fun AiTutorFloatingActionButton(
         contentColor = AiTutorColors.onPrimary,
         elevation = elevation(defaultElevation = 8.dp),
     ) {
-        Icon(Icons.Default.AutoAwesome, contentDescription = "Ask AI Tutor")
+        Icon(
+            imageVector = Icons.Default.AutoAwesome,
+            contentDescription = stringResource(Res.string.ask_ai_tutor),
+        )
     }
 }

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/viewmodel/AiTutorViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/viewmodel/AiTutorViewModel.kt
@@ -18,6 +18,9 @@ import org.catrobat.aitutor.domain.usecase.GetTutorialSeenStateUseCase
 import org.catrobat.aitutor.domain.usecase.SetTutorialSeenUseCase
 import org.catrobat.aitutor.ui.AiAppLauncher
 import org.catrobat.aitutor.ui.TutorUiStep
+import org.catrobat.shared.generated.resources.Res
+import org.catrobat.shared.generated.resources.error_loading_installed_ai_apps
+import org.jetbrains.compose.resources.getString
 
 class AiTutorViewModel(
     private val getInstalledAiAppsUseCase: GetInstalledAiAppsUseCase,
@@ -132,7 +135,12 @@ class AiTutorViewModel(
                 _uiState.update { it.copy(installedApps = apps, isLoading = false) }
             } catch (e: Exception) {
                 _uiState.update { it.copy(isLoading = false) }
-                _errorMessageFlow.emit("Failed to load installed AI apps: ${e.message}")
+                _errorMessageFlow.emit(
+                    getString(
+                        Res.string.error_loading_installed_ai_apps,
+                        e.message ?: "",
+                    ),
+                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/viewmodel/AiTutorViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/viewmodel/AiTutorViewModel.kt
@@ -124,7 +124,9 @@ class AiTutorViewModel(
                 promptVersion = currentState.selectedPromptVersion,
                 systemContext = systemContext,
             )
-        aiAppLauncher.launchApp(finalPrompt, packageName)
+        viewModelScope.launch {
+            aiAppLauncher.launchApp(finalPrompt, packageName)
+        }
     }
 
     private fun loadInstalledApps() {

--- a/shared/src/iosMain/kotlin/org/catrobat/aitutor/ui/AiAppLauncher.kt
+++ b/shared/src/iosMain/kotlin/org/catrobat/aitutor/ui/AiAppLauncher.kt
@@ -1,7 +1,7 @@
 package org.catrobat.aitutor.ui
 
 actual class AiAppLauncher {
-    actual fun launchApp(
+    actual suspend fun launchApp(
         prompt: String,
         packageName: String?,
     ) {


### PR DESCRIPTION
This pull request focuses on internationalization and UI consistency across the app by moving user-facing strings into resource files and updating the UI components to use these resources. This makes the app easier to localize and ensures consistent wording throughout the interface. Additionally, the About screen and tutorial content have been updated to use the new resources, and documentation now references all relevant repositories.

**Internationalization and UI Consistency:**
* Added all user-facing strings to `shared/src/commonMain/composeResources/values/strings.xml` for easier localization and reuse.
* Updated UI components (`InputView.kt`, `AppChooserView.kt`, `MoreChip.kt`, `TutorialView.kt`, `AboutScreen.kt`) to use `stringResource` for displaying text and content descriptions, replacing hardcoded strings throughout the app.

**Tutorial and About Screen Improvements:**
* Refactored tutorial content to use string resources for titles and descriptions, supporting future localization and ensuring consistency.
* Updated About screen sections (app name, version, developers, source code, open source libraries) to use string resources instead of hardcoded strings.

**Documentation Update:**
* Updated `GSoC_REPORT.md` to reference all related repositories and clarify code contribution locations.