### PR TITLE
Fix double-applied modifier in AppChooserView

### DIFF
--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AppChooserView.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AppChooserView.kt
@@ -40,7 +40,7 @@ internal fun AppChooserView(
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
         Box(
-            modifier = modifier.fillMaxSize().then(modifier),
+            modifier = Modifier.fillMaxSize().then(modifier),
             contentAlignment = Alignment.BottomCenter,
         ) {
             Surface(


### PR DESCRIPTION
- Use a fresh Modifier.fillMaxSize() in AppChooserView instead of chaining the passed-in modifier twice.

- Ensure caller-provided modifiers are applied exactly once, avoiding unexpected duplicated padding/size effects.

- Keeps the dialog layout behavior predictable and easier to reason about.