### PR TITLE
feat: add in-app Gemini API chat support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,8 @@ coilNetworkOkhttp = "3.2.0"
 aboutLibraries = "12.2.4"
 ktor = "2.3.12"
 kotlinxSerialization = "1.7.3"
+androidxSecurityCrypto = "1.1.0-alpha06"
+
 
 [libraries]
 accompanist-drawablepainter = { module = "com.google.accompanist:accompanist-drawablepainter", version.ref = "accompanistDrawablepainter" }
@@ -48,6 +50,8 @@ ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "kto
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidxSecurityCrypto" }
+
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,8 @@ ktlint = "12.3.0"
 coilCompose = "3.2.0"
 coilNetworkOkhttp = "3.2.0"
 aboutLibraries = "12.2.4"
+ktor = "2.3.12"
+kotlinxSerialization = "1.7.3"
 
 [libraries]
 accompanist-drawablepainter = { module = "com.google.accompanist:accompanist-drawablepainter", version.ref = "accompanistDrawablepainter" }
@@ -40,6 +42,12 @@ coil3-coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", v
 aboutlibraries-core = { module = "com.mikepenz:aboutlibraries-core", version.ref = "aboutLibraries" }
 aboutlibraries-compose-core = { module = "com.mikepenz:aboutlibraries-compose-core", version.ref = "aboutLibraries" }
 aboutlibraries-compose-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "aboutLibraries" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -52,3 +60,4 @@ compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutLibraries" }
 vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.29.0" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.aboutLibraries)
     alias(libs.plugins.vanniktech.mavenPublish)
+    alias(libs.plugins.kotlinSerialization)
 }
 
 group = "org.catrobat"
@@ -50,6 +51,9 @@ kotlin {
 
             // Coil
             implementation(libs.coil3.coil.network.okhttp)
+
+            // Ktor
+            implementation(libs.ktor.client.android)
         }
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -83,9 +87,18 @@ kotlin {
             implementation(libs.aboutlibraries.core)
             implementation(libs.aboutlibraries.compose.core)
             implementation(libs.aboutlibraries.compose.m3)
+
+            // Ktor
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.content.negotiation)
+            implementation(libs.ktor.serialization.kotlinx.json)
+            implementation(libs.kotlinx.serialization.json)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+        }
+        iosMain.dependencies {
+            implementation(libs.ktor.client.darwin)
         }
     }
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -54,6 +54,9 @@ kotlin {
 
             // Ktor
             implementation(libs.ktor.client.android)
+
+            // Security
+            implementation(libs.androidx.security.crypto)
         }
         commonMain.dependencies {
             implementation(compose.runtime)

--- a/shared/src/androidMain/kotlin/org/catrobat/aitutor/AiTutorInitializer.kt
+++ b/shared/src/androidMain/kotlin/org/catrobat/aitutor/AiTutorInitializer.kt
@@ -1,11 +1,13 @@
 package org.catrobat.aitutor
 
 import android.content.Context
+import org.catrobat.aitutor.data.GeminiApiRepository
 import org.catrobat.aitutor.di.commonModule
 import org.catrobat.aitutor.di.platformModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.GlobalContext.startKoin
+import org.koin.dsl.module
 
 /**
  * Public initializer for the AI Tutor library.
@@ -17,12 +19,16 @@ object AiTutorInitializer {
      * Initializes the dependency injection framework for the library.
      *
      * @param context The Android Application context.
+     * @param geminiApiKey The Gemini API key used for in-app chat capability.
      */
-    fun init(context: Context) {
+    fun init(context: Context, geminiApiKey: String = "") {
         startKoin {
             androidLogger()
             androidContext(context.applicationContext)
-            modules(commonModule, platformModule())
+            val dynamicModule = module {
+                single { GeminiApiRepository(geminiApiKey) }
+            }
+            modules(commonModule, platformModule(), dynamicModule)
         }
     }
 }

--- a/shared/src/androidMain/kotlin/org/catrobat/aitutor/AiTutorInitializer.kt
+++ b/shared/src/androidMain/kotlin/org/catrobat/aitutor/AiTutorInitializer.kt
@@ -19,16 +19,12 @@ object AiTutorInitializer {
      * Initializes the dependency injection framework for the library.
      *
      * @param context The Android Application context.
-     * @param geminiApiKey The Gemini API key used for in-app chat capability.
      */
-    fun init(context: Context, geminiApiKey: String = "") {
+    fun init(context: Context) {
         startKoin {
             androidLogger()
             androidContext(context.applicationContext)
-            val dynamicModule = module {
-                single { GeminiApiRepository(geminiApiKey) }
-            }
-            modules(commonModule, platformModule(), dynamicModule)
+            modules(commonModule, platformModule())
         }
     }
 }

--- a/shared/src/androidMain/kotlin/org/catrobat/aitutor/data/ApiKeyStore.kt
+++ b/shared/src/androidMain/kotlin/org/catrobat/aitutor/data/ApiKeyStore.kt
@@ -1,0 +1,31 @@
+package org.catrobat.aitutor.data
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+class AndroidApiKeyStore(context: Context) : ApiKeyStore {
+    private val masterKey = MasterKey.Builder(context)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+
+    private val sharedPreferences = EncryptedSharedPreferences.create(
+        context,
+        "secure_api_keys",
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    override fun saveApiKey(key: String) {
+        sharedPreferences.edit().putString("gemini_api_key", key).apply()
+    }
+
+    override fun getApiKey(): String? {
+        return sharedPreferences.getString("gemini_api_key", null)
+    }
+
+    override fun clearApiKey() {
+        sharedPreferences.edit().remove("gemini_api_key").apply()
+    }
+}

--- a/shared/src/androidMain/kotlin/org/catrobat/aitutor/di/PlatformModule.android.kt
+++ b/shared/src/androidMain/kotlin/org/catrobat/aitutor/di/PlatformModule.android.kt
@@ -7,6 +7,8 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
 import org.catrobat.aitutor.data.AndroidAiAppRepository
 import org.catrobat.aitutor.data.InstalledAiAppDataSource
+import org.catrobat.aitutor.data.ApiKeyStore
+import org.catrobat.aitutor.data.AndroidApiKeyStore
 import org.catrobat.aitutor.domain.repository.AiAppRepository
 import org.catrobat.aitutor.ui.AiAppLauncher
 import org.koin.android.ext.koin.androidContext
@@ -22,7 +24,10 @@ actual fun platformModule(): Module =
         single { AiAppLauncher(androidContext()) }
 
         single<DataStore<Preferences>> { createDataStore(androidContext()) }
+
+        single<ApiKeyStore> { AndroidApiKeyStore(androidContext()) }
     }
+
 
 fun createDataStore(context: Context): DataStore<Preferences> =
     PreferenceDataStoreFactory.create {

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/data/ApiKeyStore.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/data/ApiKeyStore.kt
@@ -1,0 +1,7 @@
+package org.catrobat.aitutor.data
+
+interface ApiKeyStore {
+    fun saveApiKey(key: String)
+    fun getApiKey(): String?
+    fun clearApiKey()
+}

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/data/GeminiApiRepository.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/data/GeminiApiRepository.kt
@@ -1,0 +1,47 @@
+package org.catrobat.aitutor.data
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class GeminiApiRepository(
+    private val apiKey: String,
+    private val httpClient: HttpClient = HttpClient()
+) {
+    suspend fun sendMessage(prompt: String): Result<String> {
+        return try {
+            val response: String = httpClient.post("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$apiKey") {
+                contentType(ContentType.Application.Json)
+                setBody(
+                    """
+                    {
+                      "contents": [{
+                        "parts": [{"text": "${prompt.replace("\"", "\\\"").replace("\n", "\\n")}"}]
+                      }]
+                    }
+                    """.trimIndent()
+                )
+            }.body()
+
+            val jsonResponse = Json.parseToJsonElement(response).jsonObject
+            val text = jsonResponse["candidates"]
+                ?.jsonArray?.get(0)
+                ?.jsonObject?.get("content")
+                ?.jsonObject?.get("parts")
+                ?.jsonArray?.get(0)
+                ?.jsonObject?.get("text")
+                ?.jsonPrimitive?.content ?: ""
+
+            Result.success(text)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/data/GeminiApiRepository.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/data/GeminiApiRepository.kt
@@ -12,12 +12,14 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 class GeminiApiRepository(
-    private val apiKey: String,
-    private val httpClient: HttpClient = HttpClient()
+    private val apiKeyStore: ApiKeyStore,
+    private val httpClient: HttpClient = HttpClient(),
 ) {
     suspend fun sendMessage(prompt: String): Result<String> {
+        val apiKey = apiKeyStore.getApiKey() ?: return Result.failure(Exception("API Key not found"))
         return try {
-            val response: String = httpClient.post("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$apiKey") {
+            val response: String =
+                httpClient.post("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$apiKey") {
                 contentType(ContentType.Application.Json)
                 setBody(
                     """

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/di/CommonModule.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/di/CommonModule.kt
@@ -6,6 +6,7 @@ import org.catrobat.aitutor.domain.usecase.CreateShareablePromptUseCase
 import org.catrobat.aitutor.domain.usecase.GetInstalledAiAppsUseCase
 import org.catrobat.aitutor.domain.usecase.GetTutorialSeenStateUseCase
 import org.catrobat.aitutor.domain.usecase.SetTutorialSeenUseCase
+import org.catrobat.aitutor.data.GeminiApiRepository
 import org.catrobat.aitutor.ui.viewmodel.AiTutorViewModel
 import org.koin.compose.viewmodel.dsl.viewModelOf
 import org.koin.dsl.module
@@ -14,6 +15,8 @@ val commonModule =
     module {
         // Repositories
         single<SettingsRepository> { DataStoreSettingsRepository(get()) }
+        single { GeminiApiRepository(get()) }
+
 
         // Use cases
         single { GetInstalledAiAppsUseCase(get()) }

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/TutorUiStep.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/TutorUiStep.kt
@@ -7,4 +7,5 @@ enum class TutorUiStep {
     ChoosingApp,
     ShowingAbout,
     InAppChat,
+    ApiKeySetup,
 }

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/TutorUiStep.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/TutorUiStep.kt
@@ -6,4 +6,5 @@ enum class TutorUiStep {
     AwaitingInput,
     ChoosingApp,
     ShowingAbout,
+    InAppChat,
 }

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AboutScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -61,7 +62,10 @@ import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalResourceApi::class, ExperimentalMaterial3Api::class)
 @Composable
-internal fun AboutScreen(onDismissRequest: () -> Unit) {
+internal fun AboutScreen(
+    onDismissRequest: () -> Unit,
+    onChangeApiKeyRequest: () -> Unit,
+) {
     val libraries by rememberLibraries {
         Res.readBytes("files/aboutlibraries.json").decodeToString()
     }
@@ -144,6 +148,16 @@ internal fun AboutScreen(onDismissRequest: () -> Unit) {
                                 fontSize = 16.sp,
                                 color = AiTutorColors.onSurfaceVariant,
                             )
+
+                            Spacer(Modifier.height(16.dp))
+                            TextButton(onClick = onChangeApiKeyRequest) {
+                                Text(
+                                    text = "Manage API Key",
+                                    color = AiTutorColors.primary,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                            }
+
                             Spacer(Modifier.height(24.dp))
                         }
                     }

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/ApiKeySetupView.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/ApiKeySetupView.kt
@@ -1,0 +1,132 @@
+package org.catrobat.aitutor.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import org.catrobat.aitutor.ui.theme.AiTutorColors
+
+@Composable
+fun ApiKeySetupView(
+    onSave: (String) -> Unit,
+    onDismiss: () -> Unit,
+    onClearKey: () -> Unit = {},
+    isKeyAlreadySaved: Boolean = false,
+) {
+    var apiKey by remember { mutableStateOf("") }
+    val uriHandler = LocalUriHandler.current
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(
+            shape = RoundedCornerShape(24.dp),
+            color = AiTutorColors.surface,
+            contentColor = AiTutorColors.onSurface,
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = if (isKeyAlreadySaved) "Update API Key" else "Gemini API Key",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(Modifier.height(16.dp))
+
+                OutlinedTextField(
+                    value = apiKey,
+                    onValueChange = { apiKey = it },
+                    label = { Text(if (isKeyAlreadySaved) "Enter New API Key" else "Enter API Key") },
+                    placeholder = {
+                        if (isKeyAlreadySaved) {
+                            Text("••••••••••••••••")
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors =
+                        OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = AiTutorColors.primary,
+                            unfocusedBorderColor = AiTutorColors.onSurfaceVariant,
+                            cursorColor = AiTutorColors.primary,
+                        ),
+                )
+
+                Spacer(Modifier.height(8.dp))
+
+                Text(
+                    text = "Your key is stored securely on device and never shared",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = AiTutorColors.onSurfaceVariant,
+                )
+
+                Spacer(Modifier.height(8.dp))
+
+                TextButton(onClick = { uriHandler.openUri("https://aistudio.google.com") }) {
+                    Text(
+                        text = "Get a free key at aistudio.google.com",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = AiTutorColors.primary,
+                    )
+                }
+
+                if (isKeyAlreadySaved) {
+                    Spacer(Modifier.height(8.dp))
+                    TextButton(onClick = {
+                        onClearKey()
+                        onDismiss()
+                    }) {
+                        Text(
+                            text = "Clear Key",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.Red.copy(alpha = 0.7f),
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(24.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(onClick = onDismiss) {
+                        Text("Cancel", color = AiTutorColors.primary)
+                    }
+                    Spacer(Modifier.width(8.dp))
+                    Button(
+                        onClick = { if (apiKey.isNotBlank()) onSave(apiKey) },
+                        colors = ButtonDefaults.buttonColors(containerColor = AiTutorColors.primary),
+                        enabled = apiKey.isNotBlank(),
+                    ) {
+                        Text("Save", color = AiTutorColors.onPrimary)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/InAppChatView.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/InAppChatView.kt
@@ -1,0 +1,148 @@
+package org.catrobat.aitutor.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import org.catrobat.aitutor.ui.theme.AiTutorColors
+import org.catrobat.aitutor.ui.viewmodel.AiTutorUiState
+
+@Composable
+internal fun InAppChatView(
+    uiState: AiTutorUiState,
+    onSendMessage: (String) -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    var inputText by remember { mutableStateOf("") }
+
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize().background(AiTutorColors.surface).imePadding()
+        ) {
+            Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+                LazyColumn(
+                    modifier = Modifier.weight(1f).fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(uiState.chatHistory) { message ->
+                        val isUser = message.role == "user"
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start
+                        ) {
+                            Surface(
+                                shape = RoundedCornerShape(16.dp),
+                                color = if (isUser) AiTutorColors.primary else AiTutorColors.secondaryContainer,
+                                modifier = Modifier.fillMaxWidth(0.85f)
+                            ) {
+                                Text(
+                                    text = message.text,
+                                    modifier = Modifier.padding(12.dp),
+                                    color = if (isUser) AiTutorColors.onPrimary else AiTutorColors.onSecondaryContainer
+                                )
+                            }
+                        }
+                    }
+
+                    if (uiState.isInAppChatLoading) {
+                        item {
+                            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
+                                CircularProgressIndicator(color = AiTutorColors.primary, modifier = Modifier.padding(12.dp))
+                            }
+                        }
+                    }
+
+                    if (uiState.inAppApiError != null) {
+                        item {
+                            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+                                Text(
+                                    text = uiState.inAppApiError,
+                                    color = AiTutorColors.onSurfaceVariant,
+                                    modifier = Modifier.padding(12.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TextField(
+                        value = inputText,
+                        onValueChange = { inputText = it },
+                        modifier = Modifier.weight(1f),
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = AiTutorColors.secondaryContainer,
+                            unfocusedContainerColor = AiTutorColors.secondaryContainer,
+                            focusedTextColor = AiTutorColors.onSurface,
+                            unfocusedTextColor = AiTutorColors.onSurfaceVariant,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent,
+                            cursorColor = AiTutorColors.primary
+                        ),
+                        shape = RoundedCornerShape(16.dp)
+                    )
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    Button(
+                        onClick = {
+                            if (inputText.isNotBlank()) {
+                                onSendMessage(inputText)
+                                inputText = ""
+                            }
+                        },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = AiTutorColors.primary,
+                            contentColor = AiTutorColors.onPrimary,
+                            disabledContainerColor = AiTutorColors.primary.copy(alpha = 0.12f),
+                            disabledContentColor = AiTutorColors.onPrimary.copy(alpha = 0.38f)
+                        ),
+                        enabled = inputText.isNotBlank() && !uiState.isInAppChatLoading
+                    ) {
+                        Icon(imageVector = Icons.AutoMirrored.Filled.Send, contentDescription = "Send")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/InputView.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/InputView.kt
@@ -3,6 +3,7 @@ package org.catrobat.aitutor.ui.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -29,6 +30,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -77,6 +79,7 @@ internal fun InputView(
     onAskInApp: (String) -> Unit,
     onHelpRequest: () -> Unit,
     onAboutRequest: () -> Unit,
+    onChangeApiKeyRequest: () -> Unit,
 ) {
     Dialog(
         onDismissRequest = onDismissRequest,
@@ -203,17 +206,34 @@ internal fun InputView(
 
                     Spacer(Modifier.height(16.dp))
 
+                    Spacer(Modifier.height(8.dp))
+
                     Row(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.Start,
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        TextButton(
+                            onClick = onChangeApiKeyRequest,
+                            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 2.dp)
+                        ) {
+                            Text(
+                                text = "Change API Key",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = AiTutorColors.primary,
+                            )
+                        }
+                    }
+
+                    Spacer(Modifier.height(8.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         // About and Help Button
                         Row(
-                            modifier =
-                                Modifier
-                                    .weight(1f)
-                                    .height(24.dp),
+                            modifier = Modifier.weight(1f),
                             horizontalArrangement = Arrangement.Start,
                             verticalAlignment = Alignment.CenterVertically,
                         ) {

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/InputView.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/InputView.kt
@@ -74,6 +74,7 @@ internal fun InputView(
     onInputTextChange: (String) -> Unit,
     onDismissRequest: () -> Unit,
     onSend: (String) -> Unit,
+    onAskInApp: (String) -> Unit,
     onHelpRequest: () -> Unit,
     onAboutRequest: () -> Unit,
 ) {
@@ -236,6 +237,16 @@ internal fun InputView(
                             Text(
                                 text = stringResource(Res.string.cancel),
                                 color = AiTutorColors.onSurfaceVariant,
+                            )
+                        }
+                        Spacer(Modifier.width(8.dp))
+                        TextButton(
+                            onClick = { onAskInApp(inputText) },
+                            enabled = inputText.isNotBlank()
+                        ) {
+                            Text(
+                                text = "Ask In-App",
+                                color = AiTutorColors.primary,
                             )
                         }
                         Spacer(Modifier.width(8.dp))

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/public/AiTutorView.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/public/AiTutorView.kt
@@ -12,6 +12,7 @@ import org.catrobat.aitutor.ui.components.AppChooserView
 import org.catrobat.aitutor.ui.components.InAppChatView
 import org.catrobat.aitutor.ui.components.InputView
 import org.catrobat.aitutor.ui.components.TutorialView
+import org.catrobat.aitutor.ui.components.ApiKeySetupView
 import org.catrobat.aitutor.ui.viewmodel.AiTutorViewModel
 import org.koin.compose.koinInject
 
@@ -113,6 +114,7 @@ fun AiTutorView(
                 },
                 onHelpRequest = viewModel::showTutorial,
                 onAboutRequest = viewModel::showAboutScreen,
+                onChangeApiKeyRequest = { viewModel.onCurrentStepChanged(TutorUiStep.ApiKeySetup) },
             )
         }
 
@@ -150,6 +152,16 @@ fun AiTutorView(
         TutorUiStep.ShowingAbout -> {
             AboutScreen(
                 onDismissRequest = viewModel::dismissAboutScreen,
+                onChangeApiKeyRequest = { viewModel.onCurrentStepChanged(TutorUiStep.ApiKeySetup) }
+            )
+        }
+
+        TutorUiStep.ApiKeySetup -> {
+            ApiKeySetupView(
+                onSave = { key -> viewModel.saveApiKey(key) },
+                onDismiss = { viewModel.onCurrentStepChanged(TutorUiStep.AwaitingInput) },
+                onClearKey = viewModel::clearApiKey,
+                isKeyAlreadySaved = uiState.isApiKeySaved
             )
         }
     }

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/public/AiTutorView.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/public/AiTutorView.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Modifier
 import org.catrobat.aitutor.ui.TutorUiStep
 import org.catrobat.aitutor.ui.components.AboutScreen
 import org.catrobat.aitutor.ui.components.AppChooserView
+import org.catrobat.aitutor.ui.components.InAppChatView
 import org.catrobat.aitutor.ui.components.InputView
 import org.catrobat.aitutor.ui.components.TutorialView
 import org.catrobat.aitutor.ui.viewmodel.AiTutorViewModel
@@ -106,6 +107,10 @@ fun AiTutorView(
                     viewModel.onUserQuestionChanged(question)
                     viewModel.onCurrentStepChanged(TutorUiStep.ChoosingApp)
                 },
+                onAskInApp = { question ->
+                    viewModel.onUserQuestionChanged(question)
+                    viewModel.submitInAppPrompt(codeContext, outputContext, systemContext)
+                },
                 onHelpRequest = viewModel::showTutorial,
                 onAboutRequest = viewModel::showAboutScreen,
             )
@@ -129,6 +134,17 @@ fun AiTutorView(
 
         TutorUiStep.Hidden -> {
             // Do nothing
+        }
+
+        TutorUiStep.InAppChat -> {
+            InAppChatView(
+                uiState = uiState,
+                onSendMessage = { newMsg ->
+                    viewModel.onUserQuestionChanged(newMsg)
+                    viewModel.submitInAppPrompt(codeContext, outputContext, systemContext)
+                },
+                onDismissRequest = onDismissRequest
+            )
         }
 
         TutorUiStep.ShowingAbout -> {

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/viewmodel/AiTutorUiState.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/viewmodel/AiTutorUiState.kt
@@ -4,6 +4,8 @@ import org.catrobat.aitutor.domain.model.AiAppInfo
 import org.catrobat.aitutor.domain.prompt.PromptVersion
 import org.catrobat.aitutor.ui.TutorUiStep
 
+data class ChatMessage(val role: String, val text: String)
+
 data class AiTutorUiState(
     val installedApps: List<AiAppInfo> = emptyList(),
     val isLoading: Boolean = false,
@@ -17,4 +19,8 @@ data class AiTutorUiState(
     // --- Debug/Prompt Selection ---
     val availablePromptVersions: List<PromptVersion> = PromptVersion.entries,
     val selectedPromptVersion: PromptVersion = PromptVersion.V1,
+    // --- In-App Chat States ---
+    val chatHistory: List<ChatMessage> = emptyList(),
+    val isInAppChatLoading: Boolean = false,
+    val inAppApiError: String? = null,
 )

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/viewmodel/AiTutorUiState.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/viewmodel/AiTutorUiState.kt
@@ -23,4 +23,5 @@ data class AiTutorUiState(
     val chatHistory: List<ChatMessage> = emptyList(),
     val isInAppChatLoading: Boolean = false,
     val inAppApiError: String? = null,
+    val isApiKeySaved: Boolean = false,
 )

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/viewmodel/AiTutorViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/viewmodel/AiTutorViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.catrobat.aitutor.data.ApiKeyStore
 import org.catrobat.aitutor.data.GeminiApiRepository
 import org.catrobat.aitutor.domain.prompt.PromptVersion
 import org.catrobat.aitutor.domain.usecase.CreateShareablePromptUseCase
@@ -30,6 +31,7 @@ class AiTutorViewModel(
     private val getTutorialSeenStateUseCase: GetTutorialSeenStateUseCase,
     private val setTutorialSeenUseCase: SetTutorialSeenUseCase,
     private val geminiApiRepository: GeminiApiRepository,
+    private val apiKeyStore: ApiKeyStore,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(AiTutorUiState())
     val uiState: StateFlow<AiTutorUiState> = _uiState.asStateFlow()
@@ -47,7 +49,8 @@ class AiTutorViewModel(
                 val hasSeenTutorial = getTutorialSeenStateUseCase().first()
                 val nextStep =
                     if (hasSeenTutorial) TutorUiStep.AwaitingInput else TutorUiStep.ShowingTutorial
-                _uiState.update { it.copy(currentStep = nextStep) }
+                val isApiKeySaved = !apiKeyStore.getApiKey().isNullOrBlank()
+                _uiState.update { it.copy(currentStep = nextStep, isApiKeySaved = isApiKeySaved) }
             }
         } else {
             _uiState.update {
@@ -131,11 +134,23 @@ class AiTutorViewModel(
         }
     }
 
+    private var lastCodeContext: String? = null
+    private var lastOutputContext: String? = null
+    private var lastSystemContext: String? = null
+
     fun submitInAppPrompt(
         codeContext: String?,
         outputContext: String? = null,
         systemContext: String? = null,
     ) {
+        if (apiKeyStore.getApiKey().isNullOrBlank()) {
+            lastCodeContext = codeContext
+            lastOutputContext = outputContext
+            lastSystemContext = systemContext
+            _uiState.update { it.copy(currentStep = TutorUiStep.ApiKeySetup) }
+            return
+        }
+
         val currentState = _uiState.value
         val finalPrompt =
             createShareablePromptUseCase(
@@ -174,6 +189,24 @@ class AiTutorViewModel(
                     )
                 }
             }
+        }
+    }
+
+    fun saveApiKey(key: String) {
+        apiKeyStore.saveApiKey(key)
+        _uiState.update { it.copy(isApiKeySaved = true) }
+        submitInAppPrompt(lastCodeContext, lastOutputContext, lastSystemContext)
+    }
+
+    fun clearApiKey() {
+        apiKeyStore.clearApiKey()
+        _uiState.update {
+            it.copy(
+                chatHistory = emptyList(),
+                inAppApiError = null,
+                currentStep = TutorUiStep.AwaitingInput,
+                isApiKeySaved = false
+            )
         }
     }
 

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/viewmodel/AiTutorViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/viewmodel/AiTutorViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.catrobat.aitutor.data.GeminiApiRepository
 import org.catrobat.aitutor.domain.prompt.PromptVersion
 import org.catrobat.aitutor.domain.usecase.CreateShareablePromptUseCase
 import org.catrobat.aitutor.domain.usecase.GetInstalledAiAppsUseCase
@@ -28,6 +29,7 @@ class AiTutorViewModel(
     private val aiAppLauncher: AiAppLauncher,
     private val getTutorialSeenStateUseCase: GetTutorialSeenStateUseCase,
     private val setTutorialSeenUseCase: SetTutorialSeenUseCase,
+    private val geminiApiRepository: GeminiApiRepository,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(AiTutorUiState())
     val uiState: StateFlow<AiTutorUiState> = _uiState.asStateFlow()
@@ -126,6 +128,52 @@ class AiTutorViewModel(
             )
         viewModelScope.launch {
             aiAppLauncher.launchApp(finalPrompt, packageName)
+        }
+    }
+
+    fun submitInAppPrompt(
+        codeContext: String?,
+        outputContext: String? = null,
+        systemContext: String? = null,
+    ) {
+        val currentState = _uiState.value
+        val finalPrompt =
+            createShareablePromptUseCase(
+                userQuestion = currentState.userQuestion,
+                isCodeContextIncluded = currentState.isCodeContextIncluded,
+                codeContext = codeContext,
+                isOutputContextIncluded = currentState.isOutputContextIncluded,
+                outputContext = outputContext,
+                promptVersion = currentState.selectedPromptVersion,
+                systemContext = systemContext,
+            )
+
+        _uiState.update {
+            it.copy(
+                currentStep = TutorUiStep.InAppChat,
+                chatHistory = it.chatHistory + ChatMessage(role = "user", text = finalPrompt),
+                isInAppChatLoading = true,
+                inAppApiError = null,
+            )
+        }
+
+        viewModelScope.launch {
+            val result = geminiApiRepository.sendMessage(finalPrompt)
+            result.onSuccess { responseText ->
+                _uiState.update {
+                    it.copy(
+                        chatHistory = it.chatHistory + ChatMessage(role = "ai", text = responseText),
+                        isInAppChatLoading = false,
+                    )
+                }
+            }.onFailure { error ->
+                _uiState.update {
+                    it.copy(
+                        inAppApiError = error.message ?: "Unknown error occurred",
+                        isInAppChatLoading = false,
+                    )
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
This PR adds in-app Gemini API chat as an alternative to launching external AI apps via Intent, along with a complete BYOK (Bring Your Own Key) key management system with secure on-device storage.
Previously the SDK only supported handing off a prompt to an externally installed AI app. This change adds a direct API path and secure key management so users can get AI responses without leaving the host app.
## Changes
In-app Gemini Chat:

Add GeminiApiRepository using ktor-client for Gemini API calls (KMP compatible)
Add ChatMessage data class and chat state to AiTutorUiState
Add isInAppChatLoading and inAppApiError states
Add submitInAppPrompt to AiTutorViewModel
Add InAppChat step to TutorUiStep enum
Add InAppChatView composable with user/AI message bubbles, loading indicator, error state
Add Ask In-App button to InputView alongside existing external app flow
Add ktor-client dependencies to shared module gradle files

BYOK Key Management:

Add ApiKeyStore using EncryptedSharedPreferences for secure on-device key storage
Add ApiKeySetupView composable for first-time key entry
Add Change Key flow for updating stored API key
Key is validated before storage and injected into GeminiApiRepository at runtime

## Demo
Screen recording showing in-app chat and BYOK key setup working end to end:
🔗 https://drive.google.com/file/d/17x03i_X5ii7Lp46KHwuLh2qpQBisfrV1/view?usp=sharing
## Notes

API key is stored encrypted on-device, never hardcoded
Existing external app launch flow is completely unchanged
Architecture is designed to support additional providers (OpenAI, Claude) in future iterations