### PR TITLE
Add Unit Tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,9 @@ coilNetworkOkhttp = "3.2.0"
 aboutLibraries = "12.2.4"
 kotlinxCoroutinesTest = "1.10.1"
 mokkery = "2.8.0"
+junit = "4.13.2"
+androidx-junit = "1.3.0"
+robolectric = "4.16.1"
 
 [libraries]
 accompanist-drawablepainter = { module = "com.google.accompanist:accompanist-drawablepainter", version.ref = "accompanistDrawablepainter" }
@@ -43,6 +46,9 @@ coil3-coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", v
 aboutlibraries-core = { module = "com.mikepenz:aboutlibraries-core", version.ref = "aboutLibraries" }
 aboutlibraries-compose-core = { module = "com.mikepenz:aboutlibraries-compose-core", version.ref = "aboutLibraries" }
 aboutlibraries-compose-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "aboutLibraries" }
+junit = { module = "junit:junit", version.ref = "junit" }
+androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,12 +15,15 @@ ktlint = "12.3.0"
 coilCompose = "3.2.0"
 coilNetworkOkhttp = "3.2.0"
 aboutLibraries = "12.2.4"
+kotlinxCoroutinesTest = "1.10.1"
+mokkery = "2.8.0"
 
 [libraries]
 accompanist-drawablepainter = { module = "com.google.accompanist:accompanist-drawablepainter", version.ref = "accompanistDrawablepainter" }
 androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "datastore" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
@@ -52,3 +55,4 @@ compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutLibraries" }
 vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.29.0" }
+dev-mokkery = { id = "dev.mokkery", version.ref = "mokkery" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -25,6 +25,12 @@ kotlin {
                 }
             }
         }
+
+        dependencies {
+            testImplementation("junit:junit:4.13.2")
+            testImplementation("org.robolectric:robolectric:4.16")
+            testImplementation("androidx.test.ext:junit:1.3.0")
+        }
     }
 
     val xcf = XCFramework()

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -25,12 +25,6 @@ kotlin {
                 }
             }
         }
-
-        dependencies {
-            testImplementation("junit:junit:4.13.2")
-            testImplementation("org.robolectric:robolectric:4.16")
-            testImplementation("androidx.test.ext:junit:1.3.0")
-        }
     }
 
     val xcf = XCFramework()
@@ -57,6 +51,11 @@ kotlin {
 
             // Coil
             implementation(libs.coil3.coil.network.okhttp)
+        }
+        androidUnitTest.dependencies {
+            implementation(libs.junit)
+            implementation(libs.robolectric)
+            implementation(libs.androidx.junit)
         }
         commonMain.dependencies {
             implementation(compose.runtime)

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.aboutLibraries)
     alias(libs.plugins.vanniktech.mavenPublish)
+    alias(libs.plugins.dev.mokkery)
 }
 
 group = "org.catrobat"
@@ -86,6 +87,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/shared/src/androidUnitTest/kotlin/org/catrobat/aitutor/ui/AiTutorViewModelTest.kt
+++ b/shared/src/androidUnitTest/kotlin/org/catrobat/aitutor/ui/AiTutorViewModelTest.kt
@@ -67,87 +67,93 @@ class AiTutorViewModelTest {
     }
 
     private fun createViewModel() {
-        viewModel = AiTutorViewModel(
-            getInstalledAiAppsUseCase,
-            createShareablePromptUseCase,
-            aiAppLauncher,
-            getTutorialSeenStateUseCase,
-            setTutorialSeenUseCase
-        )
+        viewModel =
+            AiTutorViewModel(
+                getInstalledAiAppsUseCase,
+                createShareablePromptUseCase,
+                aiAppLauncher,
+                getTutorialSeenStateUseCase,
+                setTutorialSeenUseCase,
+            )
     }
 
     @Test
-    fun `init should load installed apps and update state on success`() = runTest {
-        val mockIcon = mock<PlatformImage>()
-        val fakeApps = listOf(AiAppInfo("Test App", "com.test.app", mockIcon))
-        everySuspend { aiAppRepository.getInstalledAiApps() } returns fakeApps
+    fun `init should load installed apps and update state on success`() =
+        runTest {
+            val mockIcon = mock<PlatformImage>()
+            val fakeApps = listOf(AiAppInfo("Test App", "com.test.app", mockIcon))
+            everySuspend { aiAppRepository.getInstalledAiApps() } returns fakeApps
 
-        createViewModel()
+            createViewModel()
 
-        val state = viewModel.uiState.value
-        assertFalse(state.isLoading)
-        assertEquals(fakeApps, state.installedApps)
-    }
-
-
-    @Test
-    fun `handleTutorVisibility should show tutorial if not seen before`() = runTest {
-        every { settingsRepository.hasSeenTutorial } returns flowOf(false)
-        createViewModel()
-
-        viewModel.handleTutorVisibility(true)
-
-        assertEquals(TutorUiStep.ShowingTutorial, viewModel.uiState.value.currentStep)
-    }
+            val state = viewModel.uiState.value
+            assertFalse(state.isLoading)
+            assertEquals(fakeApps, state.installedApps)
+        }
 
     @Test
-    fun `handleTutorVisibility should show input if tutorial has been seen`() = runTest {
-        every { settingsRepository.hasSeenTutorial } returns flowOf(true)
-        createViewModel()
+    fun `handleTutorVisibility should show tutorial if not seen before`() =
+        runTest {
+            every { settingsRepository.hasSeenTutorial } returns flowOf(false)
+            createViewModel()
 
-        viewModel.handleTutorVisibility(true)
+            viewModel.handleTutorVisibility(true)
 
-        assertEquals(TutorUiStep.AwaitingInput, viewModel.uiState.value.currentStep)
-    }
-
-    @Test
-    fun `dismissTutorial should set tutorial as seen and move to input state`() = runTest {
-        createViewModel()
-
-        viewModel.dismissTutorial()
-
-        verifySuspend { settingsRepository.setTutorialSeen(true) }
-        assertEquals(TutorUiStep.AwaitingInput, viewModel.uiState.value.currentStep)
-    }
+            assertEquals(TutorUiStep.ShowingTutorial, viewModel.uiState.value.currentStep)
+        }
 
     @Test
-    fun `launchAiApp should create prompt and prepare correct intent`() = runTest {
-        val userQuestion = "My question"
-        val codeContext = "val code = 1"
-        val packageName = "com.test.app"
-        createViewModel()
-        viewModel.onUserQuestionChanged(userQuestion)
+    fun `handleTutorVisibility should show input if tutorial has been seen`() =
+        runTest {
+            every { settingsRepository.hasSeenTutorial } returns flowOf(true)
+            createViewModel()
 
-        val expectedPrompt = createShareablePromptUseCase(
-            userQuestion = userQuestion,
-            isCodeContextIncluded = true,
-            codeContext = codeContext,
-            isOutputContextIncluded = null,
-            outputContext = null,
-            promptVersion = PromptVersion.V1,
-            systemContext = null
-        )
+            viewModel.handleTutorVisibility(true)
 
-        viewModel.launchAiApp(packageName = packageName, codeContext = codeContext)
+            assertEquals(TutorUiStep.AwaitingInput, viewModel.uiState.value.currentStep)
+        }
 
-        // Use Robolectric's shadow application to check the intent
-        val shadowApp = shadowOf(ApplicationProvider.getApplicationContext<Application>())
-        val startedIntent = shadowApp.nextStartedActivity
+    @Test
+    fun `dismissTutorial should set tutorial as seen and move to input state`() =
+        runTest {
+            createViewModel()
 
-        assertNotNull(startedIntent, "An intent should have been prepared to start an activity.")
-        assertEquals(Intent.ACTION_SEND, startedIntent.action)
-        assertEquals("text/plain", startedIntent.type)
-        assertEquals(packageName, startedIntent.`package`)
-        assertEquals(expectedPrompt, startedIntent.getStringExtra(Intent.EXTRA_TEXT))
-    }
+            viewModel.dismissTutorial()
+
+            verifySuspend { settingsRepository.setTutorialSeen(true) }
+            assertEquals(TutorUiStep.AwaitingInput, viewModel.uiState.value.currentStep)
+        }
+
+    @Test
+    fun `launchAiApp should create prompt and prepare correct intent`() =
+        runTest {
+            val userQuestion = "My question"
+            val codeContext = "val code = 1"
+            val packageName = "com.test.app"
+            createViewModel()
+            viewModel.onUserQuestionChanged(userQuestion)
+
+            val expectedPrompt =
+                createShareablePromptUseCase(
+                    userQuestion = userQuestion,
+                    isCodeContextIncluded = true,
+                    codeContext = codeContext,
+                    isOutputContextIncluded = null,
+                    outputContext = null,
+                    promptVersion = PromptVersion.V1,
+                    systemContext = null,
+                )
+
+            viewModel.launchAiApp(packageName = packageName, codeContext = codeContext)
+
+            // Use Robolectric's shadow application to check the intent
+            val shadowApp = shadowOf(ApplicationProvider.getApplicationContext<Application>())
+            val startedIntent = shadowApp.nextStartedActivity
+
+            assertNotNull(startedIntent, "An intent should have been prepared to start an activity.")
+            assertEquals(Intent.ACTION_SEND, startedIntent.action)
+            assertEquals("text/plain", startedIntent.type)
+            assertEquals(packageName, startedIntent.`package`)
+            assertEquals(expectedPrompt, startedIntent.getStringExtra(Intent.EXTRA_TEXT))
+        }
 }

--- a/shared/src/androidUnitTest/kotlin/org/catrobat/aitutor/ui/AiTutorViewModelTest.kt
+++ b/shared/src/androidUnitTest/kotlin/org/catrobat/aitutor/ui/AiTutorViewModelTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -98,6 +99,7 @@ class AiTutorViewModelTest {
             createViewModel()
 
             viewModel.handleTutorVisibility(true)
+            advanceUntilIdle()
 
             assertEquals(TutorUiStep.ShowingTutorial, viewModel.uiState.value.currentStep)
         }
@@ -109,6 +111,7 @@ class AiTutorViewModelTest {
             createViewModel()
 
             viewModel.handleTutorVisibility(true)
+            advanceUntilIdle()
 
             assertEquals(TutorUiStep.AwaitingInput, viewModel.uiState.value.currentStep)
         }
@@ -119,6 +122,7 @@ class AiTutorViewModelTest {
             createViewModel()
 
             viewModel.dismissTutorial()
+            advanceUntilIdle()
 
             verifySuspend { settingsRepository.setTutorialSeen(true) }
             assertEquals(TutorUiStep.AwaitingInput, viewModel.uiState.value.currentStep)
@@ -145,6 +149,7 @@ class AiTutorViewModelTest {
                 )
 
             viewModel.launchAiApp(packageName = packageName, codeContext = codeContext)
+            advanceUntilIdle()
 
             // Use Robolectric's shadow application to check the intent
             val shadowApp = shadowOf(ApplicationProvider.getApplicationContext<Application>())

--- a/shared/src/androidUnitTest/kotlin/org/catrobat/aitutor/ui/AiTutorViewModelTest.kt
+++ b/shared/src/androidUnitTest/kotlin/org/catrobat/aitutor/ui/AiTutorViewModelTest.kt
@@ -1,0 +1,153 @@
+package org.catrobat.aitutor.ui
+
+import android.app.Application
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.catrobat.aitutor.domain.model.AiAppInfo
+import org.catrobat.aitutor.domain.model.PlatformImage
+import org.catrobat.aitutor.domain.prompt.PromptVersion
+import org.catrobat.aitutor.domain.repository.AiAppRepository
+import org.catrobat.aitutor.domain.repository.SettingsRepository
+import org.catrobat.aitutor.domain.usecase.CreateShareablePromptUseCase
+import org.catrobat.aitutor.domain.usecase.GetInstalledAiAppsUseCase
+import org.catrobat.aitutor.domain.usecase.GetTutorialSeenStateUseCase
+import org.catrobat.aitutor.domain.usecase.SetTutorialSeenUseCase
+import org.catrobat.aitutor.ui.viewmodel.AiTutorViewModel
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class AiTutorViewModelTest {
+    // Mock Repositories
+    private val aiAppRepository = mock<AiAppRepository>()
+    private val settingsRepository = mock<SettingsRepository>(MockMode.autoUnit)
+
+    // Instances of the Use Cases and Launcher
+    private val createShareablePromptUseCase = CreateShareablePromptUseCase()
+    private val getInstalledAiAppsUseCase = GetInstalledAiAppsUseCase(aiAppRepository)
+    private val getTutorialSeenStateUseCase = GetTutorialSeenStateUseCase(settingsRepository)
+    private val setTutorialSeenUseCase = SetTutorialSeenUseCase(settingsRepository)
+    private lateinit var aiAppLauncher: AiAppLauncher
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var viewModel: AiTutorViewModel
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        aiAppLauncher = AiAppLauncher(context)
+        everySuspend { aiAppRepository.getInstalledAiApps() } returns emptyList()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() {
+        viewModel = AiTutorViewModel(
+            getInstalledAiAppsUseCase,
+            createShareablePromptUseCase,
+            aiAppLauncher,
+            getTutorialSeenStateUseCase,
+            setTutorialSeenUseCase
+        )
+    }
+
+    @Test
+    fun `init should load installed apps and update state on success`() = runTest {
+        val mockIcon = mock<PlatformImage>()
+        val fakeApps = listOf(AiAppInfo("Test App", "com.test.app", mockIcon))
+        everySuspend { aiAppRepository.getInstalledAiApps() } returns fakeApps
+
+        createViewModel()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isLoading)
+        assertEquals(fakeApps, state.installedApps)
+    }
+
+
+    @Test
+    fun `handleTutorVisibility should show tutorial if not seen before`() = runTest {
+        every { settingsRepository.hasSeenTutorial } returns flowOf(false)
+        createViewModel()
+
+        viewModel.handleTutorVisibility(true)
+
+        assertEquals(TutorUiStep.ShowingTutorial, viewModel.uiState.value.currentStep)
+    }
+
+    @Test
+    fun `handleTutorVisibility should show input if tutorial has been seen`() = runTest {
+        every { settingsRepository.hasSeenTutorial } returns flowOf(true)
+        createViewModel()
+
+        viewModel.handleTutorVisibility(true)
+
+        assertEquals(TutorUiStep.AwaitingInput, viewModel.uiState.value.currentStep)
+    }
+
+    @Test
+    fun `dismissTutorial should set tutorial as seen and move to input state`() = runTest {
+        createViewModel()
+
+        viewModel.dismissTutorial()
+
+        verifySuspend { settingsRepository.setTutorialSeen(true) }
+        assertEquals(TutorUiStep.AwaitingInput, viewModel.uiState.value.currentStep)
+    }
+
+    @Test
+    fun `launchAiApp should create prompt and prepare correct intent`() = runTest {
+        val userQuestion = "My question"
+        val codeContext = "val code = 1"
+        val packageName = "com.test.app"
+        createViewModel()
+        viewModel.onUserQuestionChanged(userQuestion)
+
+        val expectedPrompt = createShareablePromptUseCase(
+            userQuestion = userQuestion,
+            isCodeContextIncluded = true,
+            codeContext = codeContext,
+            isOutputContextIncluded = null,
+            outputContext = null,
+            promptVersion = PromptVersion.V1,
+            systemContext = null
+        )
+
+        viewModel.launchAiApp(packageName = packageName, codeContext = codeContext)
+
+        // Use Robolectric's shadow application to check the intent
+        val shadowApp = shadowOf(ApplicationProvider.getApplicationContext<Application>())
+        val startedIntent = shadowApp.nextStartedActivity
+
+        assertNotNull(startedIntent, "An intent should have been prepared to start an activity.")
+        assertEquals(Intent.ACTION_SEND, startedIntent.action)
+        assertEquals("text/plain", startedIntent.type)
+        assertEquals(packageName, startedIntent.`package`)
+        assertEquals(expectedPrompt, startedIntent.getStringExtra(Intent.EXTRA_TEXT))
+    }
+}

--- a/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/CreateShareablePromptUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/CreateShareablePromptUseCaseTest.kt
@@ -1,12 +1,11 @@
 package org.catrobat.aitutor.domain.usecase
 
-import org.catrobat.aitutor.domain.prompt.V1PromptStrategy
 import org.catrobat.aitutor.domain.prompt.PromptVersion
+import org.catrobat.aitutor.domain.prompt.V1PromptStrategy
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class CreateShareablePromptUseCaseTest {
-
     private val useCase = CreateShareablePromptUseCase()
 
     @Test
@@ -16,24 +15,26 @@ class CreateShareablePromptUseCaseTest {
         val outputContext = "12345678910"
         val systemContext = "You are a programming expert."
 
-        val expectedPrompt = V1PromptStrategy().createPrompt(
-            userQuestion = userQuestion,
-            isCodeContextIncluded = true,
-            codeContext = codeContext,
-            isOutputContextIncluded = true,
-            outputContext = outputContext,
-            systemContext = systemContext
-        )
+        val expectedPrompt =
+            V1PromptStrategy().createPrompt(
+                userQuestion = userQuestion,
+                isCodeContextIncluded = true,
+                codeContext = codeContext,
+                isOutputContextIncluded = true,
+                outputContext = outputContext,
+                systemContext = systemContext,
+            )
 
-        val result = useCase(
-            userQuestion = userQuestion,
-            isCodeContextIncluded = true,
-            codeContext = codeContext,
-            isOutputContextIncluded = true,
-            outputContext = outputContext,
-            promptVersion = PromptVersion.V1,
-            systemContext = systemContext
-        )
+        val result =
+            useCase(
+                userQuestion = userQuestion,
+                isCodeContextIncluded = true,
+                codeContext = codeContext,
+                isOutputContextIncluded = true,
+                outputContext = outputContext,
+                promptVersion = PromptVersion.V1,
+                systemContext = systemContext,
+            )
 
         assertEquals(expectedPrompt, result)
     }
@@ -43,24 +44,26 @@ class CreateShareablePromptUseCaseTest {
         val userQuestion = "Why is my app crashing?"
         val codeContext = "val x = null; x!!.toString()"
 
-        val expectedPrompt = V1PromptStrategy().createPrompt(
-            userQuestion = userQuestion,
-            isCodeContextIncluded = false,
-            codeContext = codeContext,
-            isOutputContextIncluded = null,
-            outputContext = null,
-            systemContext = null
-        )
+        val expectedPrompt =
+            V1PromptStrategy().createPrompt(
+                userQuestion = userQuestion,
+                isCodeContextIncluded = false,
+                codeContext = codeContext,
+                isOutputContextIncluded = null,
+                outputContext = null,
+                systemContext = null,
+            )
 
-        val result = useCase(
-            userQuestion = userQuestion,
-            isCodeContextIncluded = false,
-            codeContext = codeContext,
-            isOutputContextIncluded = null,
-            outputContext = null,
-            promptVersion = PromptVersion.V1,
-            systemContext = null
-        )
+        val result =
+            useCase(
+                userQuestion = userQuestion,
+                isCodeContextIncluded = false,
+                codeContext = codeContext,
+                isOutputContextIncluded = null,
+                outputContext = null,
+                promptVersion = PromptVersion.V1,
+                systemContext = null,
+            )
 
         assertEquals(expectedPrompt, result)
     }

--- a/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/CreateShareablePromptUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/CreateShareablePromptUseCaseTest.kt
@@ -1,0 +1,67 @@
+package org.catrobat.aitutor.domain.usecase
+
+import org.catrobat.aitutor.domain.prompt.V1PromptStrategy
+import org.catrobat.aitutor.domain.prompt.PromptVersion
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CreateShareablePromptUseCaseTest {
+
+    private val useCase = CreateShareablePromptUseCase()
+
+    @Test
+    fun `invoke should use V1 strategy and return the correctly formatted prompt`() {
+        val userQuestion = "How does this loop work?"
+        val codeContext = "for i in 1..10 { print(i) }"
+        val outputContext = "12345678910"
+        val systemContext = "You are a programming expert."
+
+        val expectedPrompt = V1PromptStrategy().createPrompt(
+            userQuestion = userQuestion,
+            isCodeContextIncluded = true,
+            codeContext = codeContext,
+            isOutputContextIncluded = true,
+            outputContext = outputContext,
+            systemContext = systemContext
+        )
+
+        val result = useCase(
+            userQuestion = userQuestion,
+            isCodeContextIncluded = true,
+            codeContext = codeContext,
+            isOutputContextIncluded = true,
+            outputContext = outputContext,
+            promptVersion = PromptVersion.V1,
+            systemContext = systemContext
+        )
+
+        assertEquals(expectedPrompt, result)
+    }
+
+    @Test
+    fun `invoke should handle null and false contexts correctly with V1 strategy`() {
+        val userQuestion = "Why is my app crashing?"
+        val codeContext = "val x = null; x!!.toString()"
+
+        val expectedPrompt = V1PromptStrategy().createPrompt(
+            userQuestion = userQuestion,
+            isCodeContextIncluded = false,
+            codeContext = codeContext,
+            isOutputContextIncluded = null,
+            outputContext = null,
+            systemContext = null
+        )
+
+        val result = useCase(
+            userQuestion = userQuestion,
+            isCodeContextIncluded = false,
+            codeContext = codeContext,
+            isOutputContextIncluded = null,
+            outputContext = null,
+            promptVersion = PromptVersion.V1,
+            systemContext = null
+        )
+
+        assertEquals(expectedPrompt, result)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/GetInstalledAiAppsUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/GetInstalledAiAppsUseCaseTest.kt
@@ -1,0 +1,54 @@
+package org.catrobat.aitutor.domain.usecase
+
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import kotlinx.coroutines.test.runTest
+import org.catrobat.aitutor.domain.model.AiAppInfo
+import org.catrobat.aitutor.domain.model.PlatformImage
+import org.catrobat.aitutor.domain.repository.AiAppRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class GetInstalledAiAppsUseCaseTest {
+
+    private val repository = mock<AiAppRepository>()
+    private val useCase = GetInstalledAiAppsUseCase(repository)
+
+    @Test
+    fun `invoke should return list of apps from repository on success`() = runTest {
+        val mockIcon = mock<PlatformImage>()
+        val fakeApps = listOf(
+            AiAppInfo("App One", "com.app.one", mockIcon),
+            AiAppInfo("App Two", "com.app.two", mockIcon)
+        )
+        everySuspend { repository.getInstalledAiApps() } returns fakeApps
+
+        val result = useCase()
+
+        assertEquals(fakeApps, result)
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun `invoke should return an empty list if repository returns one`() = runTest {
+        everySuspend { repository.getInstalledAiApps() } returns emptyList()
+
+        val result = useCase()
+
+        assertEquals(emptyList(), result)
+    }
+
+    @Test
+    fun `invoke should propagate exception when repository throws an error`() = runTest {
+        val expectedException = RuntimeException("Failed to query packages")
+        everySuspend { repository.getInstalledAiApps() } throws expectedException
+
+        val thrownException = assertFailsWith<RuntimeException> {
+            useCase()
+        }
+        assertEquals(expectedException.message, thrownException.message)
+    }
+}

--- a/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/GetInstalledAiAppsUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/GetInstalledAiAppsUseCaseTest.kt
@@ -13,42 +13,46 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class GetInstalledAiAppsUseCaseTest {
-
     private val repository = mock<AiAppRepository>()
     private val useCase = GetInstalledAiAppsUseCase(repository)
 
     @Test
-    fun `invoke should return list of apps from repository on success`() = runTest {
-        val mockIcon = mock<PlatformImage>()
-        val fakeApps = listOf(
-            AiAppInfo("App One", "com.app.one", mockIcon),
-            AiAppInfo("App Two", "com.app.two", mockIcon)
-        )
-        everySuspend { repository.getInstalledAiApps() } returns fakeApps
+    fun `invoke should return list of apps from repository on success`() =
+        runTest {
+            val mockIcon = mock<PlatformImage>()
+            val fakeApps =
+                listOf(
+                    AiAppInfo("App One", "com.app.one", mockIcon),
+                    AiAppInfo("App Two", "com.app.two", mockIcon),
+                )
+            everySuspend { repository.getInstalledAiApps() } returns fakeApps
 
-        val result = useCase()
+            val result = useCase()
 
-        assertEquals(fakeApps, result)
-        assertEquals(2, result.size)
-    }
-
-    @Test
-    fun `invoke should return an empty list if repository returns one`() = runTest {
-        everySuspend { repository.getInstalledAiApps() } returns emptyList()
-
-        val result = useCase()
-
-        assertEquals(emptyList(), result)
-    }
-
-    @Test
-    fun `invoke should propagate exception when repository throws an error`() = runTest {
-        val expectedException = RuntimeException("Failed to query packages")
-        everySuspend { repository.getInstalledAiApps() } throws expectedException
-
-        val thrownException = assertFailsWith<RuntimeException> {
-            useCase()
+            assertEquals(fakeApps, result)
+            assertEquals(2, result.size)
         }
-        assertEquals(expectedException.message, thrownException.message)
-    }
+
+    @Test
+    fun `invoke should return an empty list if repository returns one`() =
+        runTest {
+            everySuspend { repository.getInstalledAiApps() } returns emptyList()
+
+            val result = useCase()
+
+            assertEquals(emptyList(), result)
+        }
+
+    @Test
+    fun `invoke should propagate exception when repository throws an error`() =
+        runTest {
+            val expectedException = RuntimeException("Failed to query packages")
+            everySuspend { repository.getInstalledAiApps() } throws expectedException
+
+            val thrownException =
+                assertFailsWith<RuntimeException> {
+                    useCase()
+                }
+            assertEquals(expectedException.message, thrownException.message)
+        }
 }

--- a/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/GetTutorialSeenStateUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/GetTutorialSeenStateUseCaseTest.kt
@@ -1,0 +1,36 @@
+package org.catrobat.aitutor.domain.usecase
+
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.catrobat.aitutor.domain.repository.SettingsRepository
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GetTutorialSeenStateUseCaseTest {
+
+    private val settingsRepository = mock<SettingsRepository>()
+    private val useCase = GetTutorialSeenStateUseCase(settingsRepository)
+
+    @Test
+    fun `invoke should return a flow with true when tutorial has been seen`() = runTest {
+        every { settingsRepository.hasSeenTutorial } returns flowOf(true)
+
+        val resultFlow = useCase()
+
+        assertTrue(resultFlow.first())
+    }
+
+    @Test
+    fun `invoke should return a flow with false when tutorial has not been seen`() = runTest {
+        every { settingsRepository.hasSeenTutorial } returns flowOf(false)
+
+        val resultFlow = useCase()
+
+        assertFalse(resultFlow.first())
+    }
+}

--- a/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/GetTutorialSeenStateUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/GetTutorialSeenStateUseCaseTest.kt
@@ -12,25 +12,26 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class GetTutorialSeenStateUseCaseTest {
-
     private val settingsRepository = mock<SettingsRepository>()
     private val useCase = GetTutorialSeenStateUseCase(settingsRepository)
 
     @Test
-    fun `invoke should return a flow with true when tutorial has been seen`() = runTest {
-        every { settingsRepository.hasSeenTutorial } returns flowOf(true)
+    fun `invoke should return a flow with true when tutorial has been seen`() =
+        runTest {
+            every { settingsRepository.hasSeenTutorial } returns flowOf(true)
 
-        val resultFlow = useCase()
+            val resultFlow = useCase()
 
-        assertTrue(resultFlow.first())
-    }
+            assertTrue(resultFlow.first())
+        }
 
     @Test
-    fun `invoke should return a flow with false when tutorial has not been seen`() = runTest {
-        every { settingsRepository.hasSeenTutorial } returns flowOf(false)
+    fun `invoke should return a flow with false when tutorial has not been seen`() =
+        runTest {
+            every { settingsRepository.hasSeenTutorial } returns flowOf(false)
 
-        val resultFlow = useCase()
+            val resultFlow = useCase()
 
-        assertFalse(resultFlow.first())
-    }
+            assertFalse(resultFlow.first())
+        }
 }

--- a/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/SetTutorialSeenUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/SetTutorialSeenUseCaseTest.kt
@@ -1,0 +1,28 @@
+package org.catrobat.aitutor.domain.usecase
+
+import dev.mokkery.MockMode
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import org.catrobat.aitutor.domain.repository.SettingsRepository
+import kotlin.test.Test
+
+class SetTutorialSeenUseCaseTest {
+
+    private val settingsRepository = mock<SettingsRepository>(MockMode.autoUnit)
+    private val useCase = SetTutorialSeenUseCase(settingsRepository)
+
+    @Test
+    fun `invoke with true should call repository setTutorialSeen with true`() = runTest {
+        useCase(true)
+
+        verifySuspend { settingsRepository.setTutorialSeen(true) }
+    }
+
+    @Test
+    fun `invoke with false should call repository setTutorialSeen with false`() = runTest {
+        useCase(false)
+
+        verifySuspend { settingsRepository.setTutorialSeen(false) }
+    }
+}

--- a/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/SetTutorialSeenUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/org/catrobat/aitutor/domain/usecase/SetTutorialSeenUseCaseTest.kt
@@ -8,21 +8,22 @@ import org.catrobat.aitutor.domain.repository.SettingsRepository
 import kotlin.test.Test
 
 class SetTutorialSeenUseCaseTest {
-
     private val settingsRepository = mock<SettingsRepository>(MockMode.autoUnit)
     private val useCase = SetTutorialSeenUseCase(settingsRepository)
 
     @Test
-    fun `invoke with true should call repository setTutorialSeen with true`() = runTest {
-        useCase(true)
+    fun `invoke with true should call repository setTutorialSeen with true`() =
+        runTest {
+            useCase(true)
 
-        verifySuspend { settingsRepository.setTutorialSeen(true) }
-    }
+            verifySuspend { settingsRepository.setTutorialSeen(true) }
+        }
 
     @Test
-    fun `invoke with false should call repository setTutorialSeen with false`() = runTest {
-        useCase(false)
+    fun `invoke with false should call repository setTutorialSeen with false`() =
+        runTest {
+            useCase(false)
 
-        verifySuspend { settingsRepository.setTutorialSeen(false) }
-    }
+            verifySuspend { settingsRepository.setTutorialSeen(false) }
+        }
 }


### PR DESCRIPTION
This pull request adds unit tests for several domain use cases and the `AiTutorViewModel`, and introduces new testing dependencies and plugins to the project configuration. The changes improve test coverage for business logic and UI state management, and set up the project for easier mocking and coroutine testing.

**Testing infrastructure and dependencies:**

* Added `kotlinx-coroutines-test` and `mokkery` libraries to `gradle/libs.versions.toml` for coroutine and mocking support in tests.
* Registered the `dev.mokkery` plugin in `gradle/libs.versions.toml` and applied it in `shared/build.gradle.kts`. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR58) [[2]](diffhunk://#diff-cf9ae3b1eb7273a914f22b1e6d22d8447f88df0e7245a5b856fb751e507b979bR12)
* Added common test dependencies (`junit`, `robolectric`, and AndroidX test) for Android unit testing in `shared/build.gradle.kts`.
* Updated `shared/build.gradle.kts` to include new test libraries for common and Android-specific tests.

**New and improved unit tests:**

* Added `AiTutorViewModelTest` to cover initialization, tutorial visibility logic, tutorial dismissal, and AI app launching behaviors, using Robolectric and Mokkery for Android-specific and coroutine testing.
* Added unit tests for core use cases: `CreateShareablePromptUseCaseTest`, `GetInstalledAiAppsUseCaseTest`, `GetTutorialSeenStateUseCaseTest`, and `SetTutorialSeenUseCaseTest`, each verifying correct behavior and error handling. [[1]](diffhunk://#diff-1fce94fa1b0e208b8e8fc92871489ce204e357240dd2b88c652a8f80e5d04899R1-R70) [[2]](diffhunk://#diff-ee1cb37fffe69ff5fbb5882484cfe88d37c3a0cde3fc19b49c3bae6d6f7a7afcR1-R58) [[3]](diffhunk://#diff-6a78c715eee6c47cd7b7a67baeba83fdfa86b12869cbe4533deda2cbb80842cfR1-R37) [[4]](diffhunk://#diff-2f65cc89265cf3cf5635399ded9e5918ff67745033bdd5314e103a4a97fa2311R1-R29)