### PR TITLE
Fix modifier chaining in AppChooserView

### DIFF
--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AppChooserView.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/AppChooserView.kt
@@ -40,7 +40,7 @@ internal fun AppChooserView(
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
         Box(
-            modifier = modifier.fillMaxSize().then(modifier),
+            modifier = modifier.fillMaxSize(),
             contentAlignment = Alignment.BottomCenter,
         ) {
             Surface(


### PR DESCRIPTION
This PR fixes a double-applied modifier issue in AppChooserView.

Previously, the modifier was applied twice using `.then(modifier)` along with `modifier.fillMaxSize()`, which could lead to redundant UI behavior.

The fix removes the unnecessary `.then(modifier)` call and ensures the modifier is applied only once.

This improves UI consistency, avoids duplication, and makes the code cleaner and more maintainable.

<img width="1554" height="868" alt="Screenshot 2026-03-31 213911" src="https://github.com/user-attachments/assets/0fbd7317-89f4-42ea-a2f5-5a63bdd7c54f" />


<img width="1874" height="904" alt="Screenshot 2026-03-31 213319" src="https://github.com/user-attachments/assets/3176bf76-92dd-4880-993d-4ea76ba1247d" />


<img width="1605" height="880" alt="Screenshot 2026-03-31 213657" src="https://github.com/user-attachments/assets/a1f01385-e55b-42e7-84b7-9bdbce375cab" />
