### PR TITLE
Add Pocket Code sprite XML agent skill and reference documentation

### DIFF
--- a/skills/pocketcode-sprite-xml/SKILL.md
+++ b/skills/pocketcode-sprite-xml/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: pocketcode-sprite-xml
+description: Authoritative reference for the Catroid/Pocket Code sprite XML format produced by XstreamSerializer.getXmlAsStringFromSprite and parsed by getSpriteFromXmlStringOrThrow. Use when generating sprite XML test fixtures, writing or debugging AI-tutor sprite responses, validating object/script/brick/formula XML elements, designing prompts that emit sprite XML, or diagnosing AiTutorSpriteValidator and XStream parse failures.
+---
+
+# PocketCode Sprite XML
+
+Generate and edit sprite XML that imports cleanly into Pocket Code (Catroid).
+This file holds the load-bearing rules; full inventories live in `references/`
+(see the pointer table at the bottom). All XML structures were verified against
+the project's actual serializer output, and all name catalogs (brick types,
+formula categories, operators, functions, sensors) against its source code.
+
+## Sprite skeleton (canonical child order)
+
+```xml
+<object type="Sprite" name="SpriteName">
+  <lookList>
+    <look fileName="12345.png" name="Look1">
+      <isWebRequest>false</isWebRequest>
+      <valid>true</valid>
+    </look>
+  </lookList>
+  <soundList>
+    <sound fileName="999.mp3" name="Music">
+      <midiFile>false</midiFile>
+    </sound>
+  </soundList>
+  <scriptList>
+    <script type="StartScript" posX="0.0" posY="0.0">
+      <brickList>
+        <brick type="SetXBrick">
+          <brickId>uuid-v4</brickId>
+          <commentedOut>false</commentedOut>
+          <formulaList>
+            <formula category="X_POSITION">
+              <additionalChildren/>
+              <type>NUMBER</type>
+              <value>0</value>
+            </formula>
+          </formulaList>
+        </brick>
+      </brickList>
+      <commentedOut>false</commentedOut>
+      <scriptId>uuid-v4</scriptId>
+    </script>
+  </scriptList>
+  <nfcTagList/>
+  <userVariables/>
+  <userLists/>
+  <userDefinedBrickList/>
+</object>
+```
+
+`type` is the sprite class name: `Sprite` (normal), `GroupSprite`, `GroupItemSprite`.
+
+## Three serializer-wide rules
+
+1. **Sprite children appear in exactly the order shown above** (fixed by
+   annotation). Everything else serializes **superclass fields first, then
+   alphabetically within each class** — e.g. on a brick: `brickId`,
+   `commentedOut` (base), then `formulaList`, then subclass fields A→Z.
+2. **`null` fields are omitted entirely** — never write an empty element for an
+   unset field. **Empty lists are kept** as self-closing tags: `<lookList/>`,
+   `<brickList/>`, `<formulaList/>`, `<loopBricks/>`.
+3. **Scripts use `<formulaMap>`, bricks use `<formulaList>`.** A
+   `WhenConditionScript`'s trigger condition lives in `<formulaMap>` directly
+   under `<script>`; every brick formula lives in `<formulaList>`. Mixing these
+   up fails import.
+
+## Composite bricks — the #1 crash cause
+
+IF/ELSE and loops are **one brick with nested children**, never flat siblings:
+
+```xml
+<!-- ✅ valid -->
+<brick type="IfLogicBeginBrick">
+  <brickId>uuid</brickId>
+  <commentedOut>false</commentedOut>
+  <formulaList>
+    <formula category="IF_CONDITION">...</formula>
+  </formulaList>
+  <elseBranchBricks>   <!-- else comes FIRST (alphabetical) -->
+    <brick type="...">...</brick>
+  </elseBranchBricks>
+  <ifBranchBricks>
+    <brick type="...">...</brick>
+  </ifBranchBricks>
+</brick>
+
+<!-- ❌ invalid: parses but crashes at runtime -->
+<brick type="IfLogicBeginBrick">...</brick>
+<brick type="SetLookBrick">...</brick>
+<brick type="IfLogicElseBrick"/>
+<brick type="IfLogicEndBrick"/>
+```
+
+- Loops (`ForeverBrick`, `RepeatBrick`, `RepeatUntilBrick`,
+  `ForVariableFromToBrick`, `ForItemInUserListBrick`, `ParameterizedBrick`)
+  nest their body in `<loopBricks>`.
+- If/else (`IfLogicBeginBrick`, `RaspiIfLogicBeginBrick`,
+  `PhiroIfLogicBeginBrick`) nest in `<elseBranchBricks>` + `<ifBranchBricks>`;
+  `IfThenLogicBeginBrick` has only `<ifBranchBricks>`.
+- **Never emit** `IfLogicElseBrick`, `IfLogicEndBrick`, `IfThenLogicEndBrick`,
+  `LoopEndBrick`, or `LoopEndlessBrick` — they exist only so legacy files parse.
+- Exception: `ParameterizedBrick` serializes a nested `<endBrick
+  type="ParameterizedEndBrick">` *element* (never a sibling brick).
+
+## Formula cheat sheet
+
+A formula is a binary expression tree. Node types: `NUMBER`, `STRING`,
+`OPERATOR`, `FUNCTION`, `SENSOR`, `USER_VARIABLE`, `USER_LIST`,
+`USER_DEFINED_BRICK_INPUT`, `BRACKET`, `COLLISION_FORMULA`.
+
+```xml
+<formula category="X_POSITION_CHANGE">  <!-- category = BrickField slot name -->
+  <additionalChildren/>
+  <leftChild>
+    <additionalChildren/>
+    <type>SENSOR</type>
+    <value>OBJECT_X</value>
+  </leftChild>
+  <rightChild>
+    <additionalChildren/>
+    <type>NUMBER</type>
+    <value>10</value>
+  </rightChild>
+  <type>OPERATOR</type>
+  <value>PLUS</value>
+</formula>
+```
+
+- Binary operators need both children; unary minus / `LOGICAL_NOT` omit `<leftChild>`.
+- `<additionalChildren/>` is present in **every** node — empty except for
+  three-argument functions (`JOIN3`, `IF_THEN_ELSE`), where it wraps the third
+  argument in `<org.catrobat.catroid.formulaeditor.FormulaElement>` elements.
+- `COLLISION_FORMULA` is a leaf whose `value` is the *other sprite's name*.
+- On user-defined (custom) brick calls, formulas are keyed `input="paramName"`
+  instead of `category="..."`.
+
+## Rules for editing existing sprite XML
+
+1. Never change a `brickId` or `scriptId`; new bricks get a fresh UUID v4.
+2. Preserve `commentedOut` values unless asked to enable/disable.
+3. Preserve `reference="..."` attributes (looks, sounds, variables, sprites)
+   exactly; inline a full block only for the first occurrence or a new object.
+4. Formula trees must be complete — correct child count for every operator/function.
+5. `posX`/`posY` on scripts are cosmetic; leave them unchanged.
+6. Return only the modified `<object>` element, no `code.xml` wrapper or XML declaration.
+7. Use only verified `BrickField` category names, brick types, and script types
+   (see references) — never invent names.
+8. For `PointToBrick`/`GoToBrick`/`CloneBrick`, keep existing sprite
+   references/inline blocks; never invent a nested sprite. `CloneBrick` without
+   `<objectToClone>` clones itself.
+9. Script-wrapper bricks (`WhenStartedBrick`, `BroadcastReceiverBrick`, …)
+   never appear in a `<brickList>` — events are `<script>` elements.
+
+## How this XML is consumed (Catroid repo)
+
+| Step | Where |
+|---|---|
+| Sprite → XML | `catroid/src/main/java/org/catrobat/catroid/io/XstreamSerializer.java` — `getXmlAsStringFromSprite()` |
+| XML → Sprite | same file — `getSpriteFromXmlStringOrThrow()` |
+| Validation | `catroid/src/main/java/org/catrobat/catroid/ui/aiassist/validation/AiTutorSpriteValidator.kt` — 3 passes: `setParents()`, formula completeness per brick field, `getView()` dry-run |
+| Apply | `catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/ScriptFragment.java` — `applyProjectFromAiTutor()` |
+| Legal type names | the `xstream.alias(...)` registry in `XstreamSerializer.java` (219 bricks, 13 scripts) |
+
+Typical validator failures: a `FormulaBrick` missing a required `category`
+entry ("SetXBrick is missing a required value (X_POSITION)"), broken parent
+chains from flat composite siblings, unknown brick `type` (fails already at parse).
+
+## Detailed references
+
+| Need | Read |
+|---|---|
+| `<object>` children: looks, sounds, NFC tags, variables, lists, XStream references, sprite-embedding bricks | `references/sprite-structure.md` |
+| All 13 script types and their extra fields, `formulaMap` | `references/scripts.md` |
+| Operators (15), functions (53), sensors (165), formula tree edge cases | `references/formulas.md` |
+| Every standard brick with description + serialized fields (motion, looks, sound, control, data, pen, testing…) | `references/bricks-core.md` |
+| Hardware bricks (Lego, Drone, Sumo, Phiro, Arduino, Raspberry Pi, NFC, embroidery, plotter, laser) | `references/bricks-hardware.md` |
+| Composite nesting in depth, `ParameterizedBrick`, custom bricks (`UserDefinedBrick`/`UserDefinedScript`), `userDataList` | `references/composite-and-userdefined.md` |
+| Complete, import-verified sprite XML examples (valid + invalid) | `references/examples.md` |

--- a/skills/pocketcode-sprite-xml/references/bricks-core.md
+++ b/skills/pocketcode-sprite-xml/references/bricks-core.md
@@ -1,0 +1,216 @@
+# Brick reference — core categories
+
+Every brick always has `<brickId>` (UUID) and `<commentedOut>`; the fields
+column lists only what comes in addition. `UPPER_CASE` names are `<formula
+category="...">` entries inside `<formulaList>`; `<lowerCase>` names are plain
+child elements. "—" = base fields only. Optional object fields (`look`,
+`sound`, `userVariable`, sprite refs) are omitted while null/unset.
+
+Hardware bricks (Lego, Drone, Sumo, Phiro, Arduino, Raspi, NFC, embroidery,
+plotter, laser) are in `references/bricks-hardware.md`.
+
+## Script-wrapper bricks — never in `<brickList>`
+
+`WhenStartedBrick`, `WhenBrick`, `WhenTouchDownBrick`, `WhenClonedBrick`,
+`WhenConditionBrick`, `WhenBackgroundChangesBrick`, `WhenBounceOffBrick`,
+`WhenGamepadButtonBrick`, `WhenNfcBrick`, `WhenRaspiPinChangedBrick`,
+`BroadcastReceiverBrick`, `UserDefinedReceiverBrick`, `EmptyEventBrick`
+are editor headers for scripts — never generate them inside a `brickList`.
+
+## Legacy marker bricks — parse-only, never emit
+
+`IfLogicElseBrick`, `IfLogicEndBrick`, `IfThenLogicEndBrick`, `LoopEndBrick`,
+`LoopEndlessBrick`. (`ParameterizedEndBrick` appears only nested in
+`ParameterizedBrick`'s `<endBrick>`.)
+
+## Motion
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `PlaceAtBrick` | Place at — teleport to X/Y coordinates | `X_POSITION`, `Y_POSITION` |
+| `SetXBrick` | Set x to — set horizontal position | `X_POSITION` |
+| `SetYBrick` | Set y to — set vertical position | `Y_POSITION` |
+| `ChangeXByNBrick` | Change x by — move horizontally by offset | `X_POSITION_CHANGE` |
+| `ChangeYByNBrick` | Change y by — move vertically by offset | `Y_POSITION_CHANGE` |
+| `GoToBrick` | Go to — jump to touch position, random position, or another sprite | `<spinnerSelection>` int: 80 = touch, 81 = random, 82 = other sprite; `<destinationSprite>` inline/reference when 82 |
+| `MoveNStepsBrick` | Move N steps in the current direction | `STEPS` |
+| `TurnLeftBrick` | Turn left by degrees | `TURN_LEFT_DEGREES` |
+| `TurnRightBrick` | Turn right by degrees | `TURN_RIGHT_DEGREES` |
+| `PointInDirectionBrick` | Point in direction (degrees, 90 = right) | `DEGREES` |
+| `PointToBrick` | Point towards another sprite | `<pointedObject>` inline sprite or reference |
+| `IfOnEdgeBounceBrick` | If on edge, bounce off the stage border | — |
+| `SetRotationStyleBrick` | Set rotation style (left-right / all-around / don't rotate) | `<selection>` int spinner index |
+| `GlideToBrick` | Glide smoothly to X/Y over a duration | `X_DESTINATION`, `Y_DESTINATION`, `DURATION_IN_SECONDS` |
+| `GoNStepsBackBrick` | Go back N layers (drawing order) | `STEPS` |
+| `ComeToFrontBrick` | Go to front — top drawing layer | — |
+| `VibrationBrick` | Vibrate the device for N seconds | `VIBRATE_DURATION_IN_SECONDS` |
+| `ArcBrick` | Go in arc — move along an arc with given radius and angle | `SIZE` (radius), `DEGREES` + `<direction>` enum (`LEFT`/`RIGHT`) |
+| `GoThroughBrick` | Go through X/Y then to a target X/Y | `X_POSITION`, `Y_POSITION`, `X_DESTINATION`, `Y_DESTINATION` + `<startCoordinates>` boolean |
+
+## Physics
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `SetPhysicsObjectTypeBrick` | Set motion type (gravity/collision behavior) | `<type>` enum: `DYNAMIC`, `FIXED`, `NONE` |
+| `SetVelocityBrick` | Set velocity to X/Y steps/second | `PHYSICS_VELOCITY_X`, `PHYSICS_VELOCITY_Y` |
+| `TurnLeftSpeedBrick` | Spin left at degrees/second | `PHYSICS_TURN_LEFT_SPEED` |
+| `TurnRightSpeedBrick` | Spin right at degrees/second | `PHYSICS_TURN_RIGHT_SPEED` |
+| `SetGravityBrick` | Set gravity for all actors/objects to X/Y | `PHYSICS_GRAVITY_X`, `PHYSICS_GRAVITY_Y` |
+| `SetMassBrick` | Set mass to N kilograms | `PHYSICS_MASS` |
+| `SetBounceBrick` | Set bounce factor (%) | `PHYSICS_BOUNCE_FACTOR` |
+| `SetFrictionBrick` | Set friction (%) | `PHYSICS_FRICTION` |
+
+## Looks
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `SetLookBrick` | Switch to a specific look | `<look>` reference/inline |
+| `SetLookByIndexBrick` | Switch to look with number | `LOOK_INDEX` |
+| `NextLookBrick` | Switch to the next look in the list | — |
+| `PreviousLookBrick` | Switch to the previous look | — |
+| `SetSizeToBrick` | Set size to N percent | `SIZE` |
+| `ChangeSizeByNBrick` | Change size by N percent | `SIZE_CHANGE` |
+| `ShowBrick` | Make the sprite visible | — |
+| `HideBrick` | Make the sprite invisible | — |
+| `SetTransparencyBrick` | Set transparency percentage | `TRANSPARENCY` |
+| `ChangeTransparencyByNBrick` | Change transparency by offset | `TRANSPARENCY_CHANGE` |
+| `SetBrightnessBrick` | Set brightness percentage | `BRIGHTNESS` |
+| `ChangeBrightnessByNBrick` | Change brightness by offset | `BRIGHTNESS_CHANGE` |
+| `SetColorBrick` | Set color effect (0–200) | `COLOR` |
+| `ChangeColorByNBrick` | Change color effect by offset | `COLOR_CHANGE` |
+| `ClearGraphicEffectBrick` | Clear all graphic effects | — |
+| `SayBubbleBrick` | Say text in a speech bubble | `STRING` |
+| `SayForBubbleBrick` | Say text for N seconds | `STRING`, `DURATION_IN_SECONDS` |
+| `ThinkBubbleBrick` | Think text in a thought bubble | `STRING` |
+| `ThinkForBubbleBrick` | Think text for N seconds | `STRING`, `DURATION_IN_SECONDS` |
+| `AskBrick` | Ask a question, store written answer in a variable | `ASK_QUESTION` + `<userVariable>` |
+| `PaintNewLookBrick` | Paint a new look in Pocket Paint and switch to it | `LOOK_NEW` (name) |
+| `EditLookBrick` | Edit the current look in Pocket Paint | — |
+| `CopyLookBrick` | Copy the current look and name the copy | `LOOK_COPY` (name) |
+| `DeleteLookBrick` | Delete the current look | — |
+| `CameraBrick` | Turn camera preview on/off | `<spinnerSelectionON>` boolean |
+| `ChooseCameraBrick` | Use front or rear camera | `<spinnerSelectionFRONT>` boolean |
+| `FlashBrick` | Turn the flashlight on/off | `<spinnerSelectionID>` int spinner index |
+| `SetCameraFocusPointBrick` | Become camera focus point | `HORIZONTAL_FLEXIBILITY`, `VERTICAL_FLEXIBILITY` |
+| `FadeParticleEffectBrick` | Fade the particle effect in/out | `<fadeSpinnerSelectionId>` int (no formulaList) |
+| `ParticleEffectAdditivityBrick` | Set particle additivity on/off | `<fadeSpinnerSelectionId>` int (no formulaList) |
+| `SetParticleColorBrick` | Set the particle effect color | `COLOR` |
+
+## Background
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `SetBackgroundBrick` | Set background to a specific look | `<look>` reference/inline |
+| `SetBackgroundByIndexBrick` | Set background to number | `BACKGROUND_INDEX` |
+| `SetBackgroundAndWaitBrick` | Set background and wait for its scripts | `<look>` reference/inline |
+| `SetBackgroundByIndexAndWaitBrick` | Set background to number and wait | `BACKGROUND_WAIT_INDEX` |
+| `LookRequestBrick` | Get image from URL, use as current look | `LOOK_REQUEST` |
+| `BackgroundRequestBrick` | Get image from URL, use as background | `BACKGROUND_REQUEST` |
+
+## Sound
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `PlaySoundBrick` | Start a sound (non-blocking) | `<sound>` reference/inline |
+| `PlaySoundAndWaitBrick` | Start a sound and wait until done | `<sound>` reference/inline |
+| `PlaySoundAtBrick` | Start a sound at an offset (seconds) | `PLAY_SOUND_AT` + `<sound>` |
+| `StopSoundBrick` | Stop a specific sound | `<sound>` reference/inline |
+| `StopAllSoundsBrick` | Stop all playing sounds | — |
+| `SetVolumeToBrick` | Set volume to N percent | `VOLUME` |
+| `ChangeVolumeByNBrick` | Change volume by offset | `VOLUME_CHANGE` |
+| `SpeakBrick` | Speak text via TTS (non-blocking) | `SPEAK` |
+| `SpeakAndWaitBrick` | Speak text and wait until done | `SPEAK` |
+| `AskSpeechBrick` | Ask, store spoken answer in a variable | `ASK_SPEECH_QUESTION` + `<userVariable>` |
+| `StartListeningBrick` | Listen to voice, store words in a variable | `<userVariable>` |
+| `SetListeningLanguageBrick` | Set speech-recognition language | `<languageObject>` |
+| `PlayNoteForBeatsBrick` | Play a MIDI note for N beats | `NOTE_TO_PLAY`, `BEATS_TO_PLAY_NOTE` |
+| `PlayDrumForBeatsBrick` | Play a drum for N beats | `PLAY_DRUM` + `<drumSelection>` enum (e.g. `SNARE_DRUM`) |
+| `SetTempoBrick` | Set tempo (BPM) | `TEMPO` |
+| `ChangeTempoByNBrick` | Change tempo by offset | `TEMPO_CHANGE` |
+| `PauseForBeatsBrick` | Pause for N beats | `BEATS_TO_PAUSE` |
+| `SetInstrumentBrick` | Choose the MIDI instrument | `<instrumentSelection>` enum (e.g. `PIANO`) |
+
+## Control
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `WaitBrick` | Wait N seconds | `TIME_TO_WAIT_IN_SECONDS` |
+| `WaitUntilBrick` | Wait until a condition is true | `IF_CONDITION` |
+| `NoteBrick` | Comment, not executed | `NOTE` |
+| `ForeverBrick` | Forever loop | body in `<loopBricks>` |
+| `RepeatBrick` | Repeat N times | `TIMES_TO_REPEAT` — body in `<loopBricks>` |
+| `RepeatUntilBrick` | Repeat until a condition is true | `REPEAT_UNTIL_CONDITION` — body in `<loopBricks>` |
+| `ForVariableFromToBrick` | For values from A to B (counter variable) | `FOR_LOOP_FROM`, `FOR_LOOP_TO` + `<userVariable>` — body in `<loopBricks>` |
+| `ForItemInUserListBrick` | For each value in a list | `<userDataList>` (`FOR_ITEM_IN_USERLIST_VARIABLE` + `FOR_ITEM_IN_USERLIST_LIST`) — body in `<loopBricks>` |
+| `IfLogicBeginBrick` | If / else | `IF_CONDITION` — `<elseBranchBricks>` + `<ifBranchBricks>` |
+| `IfThenLogicBeginBrick` | If (no else) | `IF_CONDITION` — `<ifBranchBricks>` only |
+| `StopScriptBrick` | Stop this / all / other scripts | `<spinnerSelection>` int: 0 = this, 1 = all, 2 = other |
+| `SceneTransitionBrick` | Continue another scene (resume) | `<sceneForTransition>` scene name |
+| `SceneStartBrick` | Start another scene from the beginning | `<sceneToStart>` scene name |
+| `CloneBrick` | Create clone of self or another sprite | `<objectToClone>` inline/reference; omitted = self |
+| `DeleteThisCloneBrick` | Delete this clone | — |
+| `ExitStageBrick` | Exit the stage | — |
+| `OpenUrlBrick` | Open a URL in the browser | `OPEN_URL` |
+| `ResetTimerBrick` | Reset the timer sensor to 0 | — |
+
+## Broadcast
+
+| Brick | What it does | Serialized fields |
+|---|---|---|
+| `BroadcastBrick` | Broadcast a message (non-blocking) | `<broadcastMessage>` string |
+| `BroadcastWaitBrick` | Broadcast and wait for receivers | `<broadcastMessage>` string |
+
+## Variables / Data
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `SetVariableBrick` | Set a variable to a value | `VARIABLE` + `<userVariable>` |
+| `ChangeVariableBrick` | Change a variable by an offset | `VARIABLE_CHANGE` + `<userVariable>` |
+| `ShowTextBrick` | Show variable on stage at X/Y | `X_POSITION`, `Y_POSITION` + `<userVariable>` |
+| `ShowTextColorSizeAlignmentBrick` | Show variable with size/color/alignment | `X_POSITION`, `Y_POSITION`, `SIZE`, `COLOR` + `<alignmentSelection>` int + `<userVariable>` |
+| `HideTextBrick` | Hide a shown variable | `<userVariable>` only (no formulaList) |
+| `WriteVariableOnDeviceBrick` | Persist a variable on the device | `<userVariable>` |
+| `ReadVariableFromDeviceBrick` | Load a persisted variable | `<userVariable>` |
+| `WriteVariableToFileBrick` | Write a variable to a file | `WRITE_FILENAME` + `<userVariable>` |
+| `ReadVariableFromFileBrick` | Read a variable from a file | `READ_FILENAME` + `<spinnerSelectionID>` int + `<userVariable>` |
+| `WriteListOnDeviceBrick` | Persist a list on the device | `<userList>` |
+| `ReadListFromDeviceBrick` | Load a persisted list | `<userList>` |
+| `AddItemToUserListBrick` | Add an item to a list | `LIST_ADD_ITEM` + `<userList>` |
+| `DeleteItemOfUserListBrick` | Delete the item at a position | `LIST_DELETE_ITEM` + `<userList>` |
+| `ClearUserListBrick` | Delete all items from a list | `<userList>` |
+| `InsertItemIntoUserListBrick` | Insert an item at a position | `INSERT_ITEM_INTO_USERLIST_VALUE`, `INSERT_ITEM_INTO_USERLIST_INDEX` + `<userList>` |
+| `ReplaceItemInUserListBrick` | Replace the item at a position | `REPLACE_ITEM_IN_USERLIST_VALUE`, `REPLACE_ITEM_IN_USERLIST_INDEX` + `<userList>` |
+| `StoreCSVIntoUserListBrick` | Store a CSV column into a list | `STORE_CSV_INTO_USERLIST_CSV`, `STORE_CSV_INTO_USERLIST_COLUMN` + `<userList>` |
+| `WebRequestBrick` | Send a web request, store answer in a variable | `WEB_REQUEST` + `<userVariable>` |
+| `UserDefinedBrick` | Call (or define) a custom brick | see `references/composite-and-userdefined.md` |
+
+## Pen
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `PenDownBrick` | Start drawing a line while moving | — |
+| `PenUpBrick` | Stop drawing | — |
+| `SetPenSizeBrick` | Set pen size | `PEN_SIZE` |
+| `SetPenColorBrick` | Set pen color (RGB) | `PEN_COLOR_RED`, `PEN_COLOR_GREEN`, `PEN_COLOR_BLUE` |
+| `StampBrick` | Stamp the sprite's look onto the background | — |
+| `ClearBackgroundBrick` | Clear pen lines and stamps | — |
+
+## Testing / Automation
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `AssertEqualsBrick` | Assert actual equals expected | `ASSERT_EQUALS_ACTUAL`, `ASSERT_EQUALS_EXPECTED` |
+| `AssertUserListsBrick` | Assert two lists are equal | `<userDataList>` (`ASSERT_LISTS_ACTUAL` + `ASSERT_LISTS_EXPECTED`) |
+| `ParameterizedBrick` | Run assertions per item of selected lists | `<userLists>` + nested `<endBrick>` + `<loopBricks>` |
+| `FinishStageBrick` | Finish stage / end test run | — |
+| `ReportBrick` | Report a value (test output) | `REPORT_BRICK` |
+| `TapAtBrick` | Simulate a single tap at X/Y | `X_POSITION`, `Y_POSITION` |
+| `TapForBrick` | Simulate touching at X/Y for a duration | `X_POSITION`, `Y_POSITION`, `DURATION_IN_SECONDS` |
+| `TouchAndSlideBrick` | Simulate touch-and-slide | `X_POSITION`, `Y_POSITION`, `X_POSITION_CHANGE`, `Y_POSITION_CHANGE`, `DURATION_IN_SECONDS` + `<startCoordinates>` boolean |
+| `WaitTillIdleBrick` | Wait until all other scripts stopped | — |
+
+## Misc / Legacy
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `SetTextBrick` | Legacy "set text at X/Y" overlay | `X_DESTINATION`, `Y_DESTINATION`, `STRING` |

--- a/skills/pocketcode-sprite-xml/references/bricks-hardware.md
+++ b/skills/pocketcode-sprite-xml/references/bricks-hardware.md
@@ -1,0 +1,112 @@
+# Brick reference — hardware categories
+
+Same conventions as `bricks-core.md`: `UPPER_CASE` = formula categories in
+`<formulaList>`, `<lowerCase>` = plain child elements, "—" = base fields only
+(`brickId` + `commentedOut`).
+
+These bricks appear only in projects using the corresponding hardware.
+
+## Lego NXT
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `LegoNxtMotorMoveBrick` | Move an NXT motor at a speed | `LEGO_NXT_SPEED` + `<motor>` enum (e.g. `MOTOR_A`) |
+| `LegoNxtMotorStopBrick` | Stop an NXT motor | `<motor>` enum |
+| `LegoNxtMotorTurnAngleBrick` | Turn an NXT motor by an angle | `LEGO_NXT_DEGREES` + `<motor>` enum |
+| `LegoNxtPlayToneBrick` | Play a tone on the NXT | `LEGO_NXT_FREQUENCY`, `LEGO_NXT_DURATION_IN_SECONDS` |
+
+## Lego EV3
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `LegoEv3MotorMoveBrick` | Move an EV3 motor at a speed | `LEGO_EV3_SPEED` + `<motor>` enum |
+| `LegoEv3MotorStopBrick` | Stop an EV3 motor | `<motor>` enum |
+| `LegoEv3MotorTurnAngleBrick` | Turn an EV3 motor by an angle | `LEGO_EV3_DEGREES` + `<motor>` enum |
+| `LegoEv3PlayToneBrick` | Play a tone on the EV3 | `LEGO_EV3_FREQUENCY`, `LEGO_EV3_DURATION_IN_SECONDS`, `LEGO_EV3_VOLUME` |
+| `LegoEv3SetLedBrick` | Set the EV3 LED status | `<ledStatus>` enum (e.g. `LED_GREEN`) |
+
+## AR.Drone 2.0
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `DroneTakeOffLandBrick` | Take off / land | — |
+| `DroneEmergencyBrick` | Emergency stop | — |
+| `DroneMoveForwardBrick`, `DroneMoveBackwardBrick`, `DroneMoveUpBrick`, `DroneMoveDownBrick`, `DroneMoveLeftBrick`, `DroneMoveRightBrick` | Move in a direction for a time at a power | each: `DRONE_TIME_TO_FLY_IN_SECONDS`, `DRONE_POWER_IN_PERCENT` |
+| `DroneTurnLeftBrick`, `DroneTurnRightBrick` | Turn | `DRONE_TIME_TO_FLY_IN_SECONDS`, `DRONE_POWER_IN_PERCENT` |
+| `DroneFlipBrick` | Flip | — |
+| `DroneSwitchCameraBrick` | Switch between cameras | — |
+| `DronePlayLedAnimationBrick` | Play a flash/LED animation | `<ledAnimationName>` string |
+
+## Jumping Sumo
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `JumpingSumoMoveForwardBrick`, `JumpingSumoMoveBackwardBrick` | Drive for a time at a speed | each: `JUMPING_SUMO_TIME_TO_DRIVE_IN_SECONDS`, `JUMPING_SUMO_SPEED` |
+| `JumpingSumoRotateLeftBrick`, `JumpingSumoRotateRightBrick` | Rotate by degrees | `JUMPING_SUMO_ROTATE` |
+| `JumpingSumoJumpHighBrick`, `JumpingSumoJumpLongBrick` | Jump high / long | — |
+| `JumpingSumoTurnBrick` | Flip (turn over) | — |
+| `JumpingSumoAnimationsBrick` | Play an animation | `<animationName>` enum (e.g. `SPIN`) |
+| `JumpingSumoSoundBrick` | Play a sound at a volume | `JUMPING_SUMO_VOLUME` + `<soundName>` enum (e.g. `DEFAULT`) |
+| `JumpingSumoNoSoundBrick` | Mute sounds | — |
+| `JumpingSumoTakingPictureBrick` | Take a picture | — |
+
+## Phiro
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `PhiroMotorMoveForwardBrick`, `PhiroMotorMoveBackwardBrick` | Move a motor at a speed | `PHIRO_SPEED` + `<motor>` enum (e.g. `MOTOR_LEFT`, `MOTOR_BOTH`) |
+| `PhiroMotorStopBrick` | Stop a motor | `<motor>` enum |
+| `PhiroPlayToneBrick` | Play a tone for a duration | `PHIRO_DURATION_IN_SECONDS` + `<tone>` enum (e.g. `DO`) |
+| `PhiroRGBLightBrick` | Set light color (RGB) | `PHIRO_LIGHT_RED`, `PHIRO_LIGHT_GREEN`, `PHIRO_LIGHT_BLUE` + `<eye>` enum (`LEFT`/`RIGHT`/`BOTH`) |
+| `PhiroIfLogicBeginBrick` | If a Phiro sensor is activated (if/else composite) | `<sensorSpinnerPosition>` int + `<elseBranchBricks>` / `<ifBranchBricks>` |
+
+## Arduino
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `ArduinoSendDigitalValueBrick` | Set a digital pin to a value | `ARDUINO_DIGITAL_PIN_NUMBER`, `ARDUINO_DIGITAL_PIN_VALUE` |
+| `ArduinoSendPWMValueBrick` | Set a PWM~ pin to a value | `ARDUINO_ANALOG_PIN_NUMBER`, `ARDUINO_ANALOG_PIN_VALUE` |
+
+## Raspberry Pi
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `RaspiSendDigitalValueBrick` | Set a GPIO pin to a value | `RASPI_DIGITAL_PIN_NUMBER`, `RASPI_DIGITAL_PIN_VALUE` |
+| `RaspiPwmBrick` | Set a PWM pin (frequency, duty cycle) | `RASPI_DIGITAL_PIN_NUMBER`, `RASPI_PWM_FREQUENCY`, `RASPI_PWM_PERCENTAGE` |
+| `RaspiIfLogicBeginBrick` | If a pin is high (if/else composite) | `IF_CONDITION` + `<elseBranchBricks>` / `<ifBranchBricks>` |
+
+## NFC
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `SetNfcTagBrick` | Write a message to the next scanned tag | `NFC_NDEF_MESSAGE` + `<nfcTagNdefType>` int |
+
+## Embroidery
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `StitchBrick` | Stitch at the current position | — |
+| `RunningStitchBrick` | Start running stitch with a length | `EMBROIDERY_LENGTH` |
+| `ZigZagStitchBrick` | Start zigzag stitch with length and width | `ZIGZAG_EMBROIDERY_LENGTH`, `ZIGZAG_EMBROIDERY_WIDTH` |
+| `TripleStitchBrick` | Start triple stitch with a length | `EMBROIDERY_LENGTH` |
+| `StopRunningStitchBrick` | Stop the current stitch | — |
+| `SetThreadColorBrick` | Set thread color | `THREAD_COLOR` |
+| `SewUpBrick` | Sew up (knot the thread) | — |
+| `WriteEmbroideryToFileBrick` | Write embroidery data to a file | `WRITE_FILENAME` |
+
+## Plotter
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `StartPlotBrick` / `StopPlotBrick` | Start / stop plotting | — |
+| `SavePlotBrick` | Save plot as SVG | `WRITE_FILENAME` |
+| `SharePlotBrick` | Share plot as SVG | `WRITE_FILENAME` |
+
+## Laser Cutter
+
+| Brick | What it does | Serialized fields / formula categories |
+|---|---|---|
+| `StartCutBrick` / `StopCutBrick` | Start / stop cutting | — |
+| `StartEngraveBrick` / `StopEngraveBrick` | Start / stop engraving | — |
+| `SaveLaserBrick` | Save laser data to SVG | `WRITE_FILENAME` |
+| `ShareLaserBrick` | Share laser data as SVG | `WRITE_FILENAME` |

--- a/skills/pocketcode-sprite-xml/references/composite-and-userdefined.md
+++ b/skills/pocketcode-sprite-xml/references/composite-and-userdefined.md
@@ -1,0 +1,204 @@
+# Composite bricks and custom (user-defined) bricks
+
+Nesting rules for if/else and loops, the `ParameterizedBrick` exception,
+`userDataList`, and the three linked parts of a custom brick.
+
+## Composite bricks: bodies nest, end bricks don't exist
+
+In the editor, IF/ELSE and loops look like several bricks (begin, else, end).
+**In XML they are one brick** whose body bricks nest in dedicated list elements.
+This is the single most common cause of crashes in generated XML.
+
+All 10 composite types:
+
+| Composite brick | Body nests in | Extra serialized fields |
+|---|---|---|
+| `IfLogicBeginBrick` | `<elseBranchBricks>` + `<ifBranchBricks>` — else **first** | — |
+| `RaspiIfLogicBeginBrick` | same (subclass of `IfLogicBeginBrick`) | — |
+| `PhiroIfLogicBeginBrick` | same branch lists | `<sensorSpinnerPosition>` int |
+| `IfThenLogicBeginBrick` | `<ifBranchBricks>` only | — |
+| `ForeverBrick` | `<loopBricks>` | — |
+| `RepeatBrick` | `<loopBricks>` | `TIMES_TO_REPEAT` formula |
+| `RepeatUntilBrick` | `<loopBricks>` | `REPEAT_UNTIL_CONDITION` formula |
+| `ForVariableFromToBrick` | `<loopBricks>` | `FOR_LOOP_FROM`, `FOR_LOOP_TO` + `<userVariable>` |
+| `ForItemInUserListBrick` | `<loopBricks>` | `<userDataList>` (see below) |
+| `ParameterizedBrick` | `<loopBricks>` | `<userLists>` + serialized `<endBrick>` (see below) |
+
+### ❌ Invalid IF/ELSE (flat siblings — parses, crashes at runtime)
+
+```xml
+<brick type="IfLogicBeginBrick"> ... </brick>
+<brick type="SetLookBrick"> ... </brick>
+<brick type="IfLogicElseBrick"/>
+<brick type="SetLookBrick"> ... </brick>
+<brick type="IfLogicEndBrick"/>
+```
+
+### ✅ Valid IF/ELSE (nested branches; else branch serialized first)
+
+```xml
+<brick type="IfLogicBeginBrick">
+  <brickId>uuid</brickId>
+  <commentedOut>false</commentedOut>
+  <formulaList>
+    <formula category="IF_CONDITION">...</formula>
+  </formulaList>
+  <elseBranchBricks>
+    <brick type="SetLookBrick">...</brick>
+  </elseBranchBricks>
+  <ifBranchBricks>
+    <brick type="SetLookBrick">...</brick>
+  </ifBranchBricks>
+</brick>
+```
+
+### ❌ Invalid loop / ✅ valid loop
+
+```xml
+<!-- ❌ -->
+<brick type="RepeatBrick"> ... </brick>
+<brick type="MoveNStepsBrick"> ... </brick>
+<brick type="LoopEndBrick"/>
+
+<!-- ✅ -->
+<brick type="RepeatBrick">
+  <brickId>uuid</brickId>
+  <commentedOut>false</commentedOut>
+  <formulaList>
+    <formula category="TIMES_TO_REPEAT">...</formula>
+  </formulaList>
+  <loopBricks>
+    <brick type="MoveNStepsBrick">...</brick>
+  </loopBricks>
+</brick>
+```
+
+### Rules
+
+- Empty branches/bodies are self-closing: `<ifBranchBricks/>`, `<loopBricks/>`.
+- On `IfLogicBeginBrick`, `<elseBranchBricks>` is always present (self-closing
+  when there's no else body).
+- `IfThenLogicBeginBrick` (if without else) has only `<ifBranchBricks>` and no
+  end brick.
+- Never emit `IfLogicElseBrick`, `IfLogicEndBrick`, `IfThenLogicEndBrick`,
+  `LoopEndBrick`, or `LoopEndlessBrick` as sibling bricks — they are
+  parse-only legacy types.
+
+### Exception: ParameterizedBrick serializes its end brick
+
+Uniquely, `ParameterizedBrick`'s end brick is a nested `<endBrick>` *element*
+(never a sibling), carrying an `ASSERT_LOOP_ACTUAL` formula:
+
+```xml
+<brick type="ParameterizedBrick">
+  <brickId>uuid</brickId>
+  <commentedOut>false</commentedOut>
+  <userLists/>
+  <endBrick type="ParameterizedEndBrick">
+    <brickId>uuid</brickId>
+    <commentedOut>false</commentedOut>
+    <formulaList>
+      <formula category="ASSERT_LOOP_ACTUAL">
+        <additionalChildren/>
+        <type>NUMBER</type>
+        <value>0</value>
+      </formula>
+    </formulaList>
+  </endBrick>
+  <loopBricks>
+    ...
+  </loopBricks>
+</brick>
+```
+
+## userDataList (UserDataBrick)
+
+Bricks holding *both* a variable and a list (`ForItemInUserListBrick`,
+`AssertUserListsBrick`) use a `<userDataList>` map. Variable entries get the
+custom wrapper, list entries are plain:
+
+```xml
+<brick type="ForItemInUserListBrick">
+  <brickId>uuid</brickId>
+  <commentedOut>false</commentedOut>
+  <formulaList/>
+  <userDataList>
+    <userData category="FOR_ITEM_IN_USERLIST_VARIABLE" type="UserVariable" serialization="custom">
+      <userVariable>
+        <default>
+          <initialIndex>-1</initialIndex>
+          <deviceValueKey>uuid</deviceValueKey>
+          <name>myVar</name>
+        </default>
+      </userVariable>
+    </userData>
+    <userData category="FOR_ITEM_IN_USERLIST_LIST">
+      <deviceListKey>uuid</deviceListKey>
+      <initialIndex>-1</initialIndex>
+      <name>myList</name>
+    </userData>
+  </userDataList>
+  <loopBricks/>
+</brick>
+```
+
+Categories: `FOR_ITEM_IN_USERLIST_VARIABLE`, `FOR_ITEM_IN_USERLIST_LIST`,
+`ASSERT_LISTS_EXPECTED`, `ASSERT_LISTS_ACTUAL`.
+
+## UserDefinedBrick (custom bricks)
+
+Three parts linked by the same `userDefinedBrickID` UUID:
+
+1. **Definition** in the sprite's `<userDefinedBrickList>`
+   (`<isCallingBrick>false</isCallingBrick>`).
+2. **Body**: a `UserDefinedScript` in `<scriptList>` with matching
+   `<userDefinedBrickID>`.
+3. **Calls** inside normal `brickList`s (`<isCallingBrick>true</isCallingBrick>`).
+
+Definition with one label ("jump") and one input ("height"):
+
+```xml
+<brick type="UserDefinedBrick">
+  <brickId>uuid</brickId>
+  <commentedOut>false</commentedOut>
+  <formulaList/>
+  <isCallingBrick>false</isCallingBrick>
+  <userDefinedBrickDataList>
+    <userDefinedBrickLabel>
+      <type>LABEL</type>
+      <label>jump</label>
+    </userDefinedBrickLabel>
+    <userDefinedBrickInput>
+      <type>INPUT</type>
+      <initialIndex>-1</initialIndex>
+      <input>
+        <input>height</input>
+      </input>
+    </userDefinedBrickInput>
+  </userDefinedBrickDataList>
+  <userDefinedBrickID>uuid</userDefinedBrickID>
+</brick>
+```
+
+Notes:
+
+- The field name really is `isCallingBrick` (not `callingBrick`).
+- `<userDefinedBrickInput>` double-nests the name:
+  `<input><input>height</input></input>`.
+- **Formulas on calling bricks are keyed by `input=`, not `category=`**:
+  `<formula input="height">…</formula>`.
+
+The body script:
+
+```xml
+<script type="UserDefinedScript" posX="0.0" posY="0.0">
+  <brickList>...</brickList>
+  <commentedOut>false</commentedOut>
+  <scriptId>uuid</scriptId>
+  <screenRefresh>true</screenRefresh>
+  <userDefinedBrickID>same-uuid</userDefinedBrickID>
+</script>
+```
+
+Inside the body, read a parameter with a formula node of type
+`USER_DEFINED_BRICK_INPUT` whose `value` is the parameter name.

--- a/skills/pocketcode-sprite-xml/references/examples.md
+++ b/skills/pocketcode-sprite-xml/references/examples.md
@@ -1,0 +1,262 @@
+# Complete sprite XML examples
+
+All "valid" examples below were verified to parse against the project's actual
+XStream configuration (`XstreamSerializer.getXstream()` — the same converters
+and aliases used by `getSpriteFromXmlStringOrThrow()`). UUIDs shown are real
+ones from serializer output — always generate fresh UUID v4 values for new
+bricks/scripts.
+
+## 1. Minimal sprite — one StartScript, one brick
+
+```xml
+<object type="Sprite" name="Hello">
+  <lookList/>
+  <soundList/>
+  <scriptList>
+    <script type="StartScript" posX="0.0" posY="0.0">
+      <brickList>
+        <brick type="SetXBrick">
+          <brickId>9c1c1de4-6b51-4768-a32b-9a6ae4e5e1a1</brickId>
+          <commentedOut>false</commentedOut>
+          <formulaList>
+            <formula category="X_POSITION">
+              <additionalChildren/>
+              <type>NUMBER</type>
+              <value>100</value>
+            </formula>
+          </formulaList>
+        </brick>
+      </brickList>
+      <commentedOut>false</commentedOut>
+      <scriptId>5b2a7c1e-3d4f-4a6b-8c9d-0e1f2a3b4c5d</scriptId>
+    </script>
+  </scriptList>
+  <nfcTagList/>
+  <userVariables/>
+  <userLists/>
+  <userDefinedBrickList/>
+</object>
+```
+
+## 2. Looks, sounds, variables, references, sprite-reference bricks
+
+Verbatim serializer output: shows look/sound list entries, the userVariable
+custom wrapper, second-use references, an inlined target sprite
+(`pointedObject`), and a reference to it (`objectToClone`). Note the
+sprite-level `<userVariables>` referencing back into the script.
+
+```xml
+<object type="Sprite" name="Hero">
+  <lookList>
+    <look fileName="12345.png" name="Look1">
+      <isWebRequest>false</isWebRequest>
+      <valid>true</valid>
+    </look>
+  </lookList>
+  <soundList>
+    <sound fileName="999.mp3" name="Music">
+      <midiFile>false</midiFile>
+    </sound>
+  </soundList>
+  <scriptList>
+    <script type="StartScript" posX="0.0" posY="0.0">
+      <brickList>
+        <brick type="SetVariableBrick">
+          <brickId>20f0c305-3bfc-4f53-85ba-a3cc87d905ee</brickId>
+          <commentedOut>false</commentedOut>
+          <formulaList>
+            <formula category="VARIABLE">
+              <additionalChildren/>
+              <type>NUMBER</type>
+              <value>0</value>
+            </formula>
+          </formulaList>
+          <userVariable type="UserVariable" serialization="custom">
+            <userVariable>
+              <default>
+                <initialIndex>-1</initialIndex>
+                <deviceValueKey>06bcb4cb-c281-4492-95c7-91f48a17cd5c</deviceValueKey>
+                <name>score</name>
+              </default>
+            </userVariable>
+          </userVariable>
+        </brick>
+        <brick type="SetVariableBrick">
+          <brickId>d8ba7544-ec76-44c8-8e49-06186bdcb0dc</brickId>
+          <commentedOut>false</commentedOut>
+          <formulaList>
+            <formula category="VARIABLE">
+              <additionalChildren/>
+              <type>NUMBER</type>
+              <value>1</value>
+            </formula>
+          </formulaList>
+          <userVariable reference="../../brick/userVariable"/>
+        </brick>
+        <brick type="SetLookBrick">
+          <brickId>fccd479e-0eeb-4b88-99b3-c4cb864645a7</brickId>
+          <commentedOut>false</commentedOut>
+          <look reference="../../../../../lookList/look"/>
+        </brick>
+        <brick type="PointToBrick">
+          <brickId>3c8cd8f5-5f48-449f-a8ea-6e8a8d9da1fb</brickId>
+          <commentedOut>false</commentedOut>
+          <pointedObject type="Sprite" name="Enemy">
+            <lookList/>
+            <soundList/>
+            <scriptList/>
+            <nfcTagList/>
+            <userVariables/>
+            <userLists/>
+            <userDefinedBrickList/>
+          </pointedObject>
+        </brick>
+        <brick type="CloneBrick">
+          <brickId>dcc43371-0516-4480-8051-79f3ada65c18</brickId>
+          <commentedOut>false</commentedOut>
+          <objectToClone reference="../../brick[4]/pointedObject"/>
+        </brick>
+      </brickList>
+      <commentedOut>false</commentedOut>
+      <scriptId>a2b52b04-c737-442b-8351-51ef55e7cf80</scriptId>
+    </script>
+  </scriptList>
+  <nfcTagList/>
+  <userVariables>
+    <userVariable reference="../../scriptList/script/brickList/brick/userVariable"/>
+  </userVariables>
+  <userLists/>
+  <userDefinedBrickList/>
+</object>
+```
+
+## 3. Composite-heavy: WhenScript with forever / if-else / repeat
+
+```xml
+<object type="Sprite" name="Game">
+  <lookList/>
+  <soundList/>
+  <scriptList>
+    <script type="WhenScript" posX="0.0" posY="0.0">
+      <brickList>
+        <brick type="ForeverBrick">
+          <brickId>0a98a1c2-1111-4222-8333-444455556666</brickId>
+          <commentedOut>false</commentedOut>
+          <loopBricks>
+            <brick type="IfLogicBeginBrick">
+              <brickId>1b98a1c2-1111-4222-8333-444455556666</brickId>
+              <commentedOut>false</commentedOut>
+              <formulaList>
+                <formula category="IF_CONDITION">
+                  <additionalChildren/>
+                  <leftChild>
+                    <additionalChildren/>
+                    <type>SENSOR</type>
+                    <value>OBJECT_X</value>
+                  </leftChild>
+                  <rightChild>
+                    <additionalChildren/>
+                    <type>NUMBER</type>
+                    <value>200</value>
+                  </rightChild>
+                  <type>OPERATOR</type>
+                  <value>GREATER_THAN</value>
+                </formula>
+              </formulaList>
+              <elseBranchBricks>
+                <brick type="RepeatBrick">
+                  <brickId>2c98a1c2-1111-4222-8333-444455556666</brickId>
+                  <commentedOut>false</commentedOut>
+                  <formulaList>
+                    <formula category="TIMES_TO_REPEAT">
+                      <additionalChildren/>
+                      <type>NUMBER</type>
+                      <value>10</value>
+                    </formula>
+                  </formulaList>
+                  <loopBricks>
+                    <brick type="MoveNStepsBrick">
+                      <brickId>3d98a1c2-1111-4222-8333-444455556666</brickId>
+                      <commentedOut>false</commentedOut>
+                      <formulaList>
+                        <formula category="STEPS">
+                          <additionalChildren/>
+                          <type>NUMBER</type>
+                          <value>5</value>
+                        </formula>
+                      </formulaList>
+                    </brick>
+                  </loopBricks>
+                </brick>
+              </elseBranchBricks>
+              <ifBranchBricks>
+                <brick type="SetXBrick">
+                  <brickId>4e98a1c2-1111-4222-8333-444455556666</brickId>
+                  <commentedOut>false</commentedOut>
+                  <formulaList>
+                    <formula category="X_POSITION">
+                      <additionalChildren/>
+                      <rightChild>
+                        <additionalChildren/>
+                        <type>NUMBER</type>
+                        <value>200</value>
+                      </rightChild>
+                      <type>OPERATOR</type>
+                      <value>MINUS</value>
+                    </formula>
+                  </formulaList>
+                </brick>
+              </ifBranchBricks>
+            </brick>
+          </loopBricks>
+        </brick>
+      </brickList>
+      <commentedOut>false</commentedOut>
+      <scriptId>5f98a1c2-1111-4222-8333-444455556666</scriptId>
+    </script>
+  </scriptList>
+  <nfcTagList/>
+  <userVariables/>
+  <userLists/>
+  <userDefinedBrickList/>
+</object>
+```
+
+(The `SetXBrick` formula is unary negation: `MINUS` with only a `rightChild` = `-200`.)
+
+## ❌ Invalid patterns — never generate these
+
+Flat composite siblings (parses, crashes at runtime):
+
+```xml
+<brick type="IfLogicBeginBrick"> ... </brick>
+<brick type="SetLookBrick"> ... </brick>
+<brick type="IfLogicElseBrick"/>
+<brick type="SetLookBrick"> ... </brick>
+<brick type="IfLogicEndBrick"/>
+```
+
+```xml
+<brick type="RepeatBrick"> ... </brick>
+<brick type="MoveNStepsBrick"> ... </brick>
+<brick type="LoopEndBrick"/>
+```
+
+`formulaList` on a script (fails to import — scripts use `formulaMap`):
+
+```xml
+<script type="WhenConditionScript">
+  ...
+  <formulaList>   <!-- ❌ "No such field ...Script.formulaList" -->
+    <formula category="IF_CONDITION">...</formula>
+  </formulaList>
+</script>
+```
+
+Wrapper/event bricks inside a brickList (events are `<script>` elements):
+
+```xml
+<brickList>
+  <brick type="WhenStartedBrick"/>   <!-- ❌ never in brickList -->
+</brickList>
+```

--- a/skills/pocketcode-sprite-xml/references/formulas.md
+++ b/skills/pocketcode-sprite-xml/references/formulas.md
@@ -1,0 +1,198 @@
+# Formulas: trees, operators, functions, sensors
+
+Formula expression trees and the complete value sets: 15 operators,
+53 functions, 165 sensors.
+
+## Structure
+
+Bricks store formulas in `<formulaList>`; each `<formula>`'s `category`
+attribute is the `BrickField` slot it fills (one brick can have several).
+A formula is a binary expression tree; each node:
+
+```xml
+<formula category="CATEGORY_NAME">
+  <additionalChildren/>
+  <type>ElementType</type>
+  <value>value</value>
+  <!-- optional leftChild / rightChild subtrees, same node shape -->
+</formula>
+```
+
+### Element types
+
+| `type` | Meaning | Example `value` |
+|---|---|---|
+| `NUMBER` | Literal number | `50`, `3.14` |
+| `STRING` | Literal string | `hello` |
+| `OPERATOR` | Math/logic operator | `PLUS` |
+| `FUNCTION` | Built-in function | `SQRT` |
+| `SENSOR` | Device/sprite sensor | `OBJECT_X` |
+| `USER_VARIABLE` | User variable | the variable's name |
+| `USER_LIST` | User list | the list's name |
+| `USER_DEFINED_BRICK_INPUT` | Custom-brick parameter | the parameter name |
+| `BRACKET` | Grouping parentheses | — |
+| `COLLISION_FORMULA` | Collision with another sprite | the *other sprite's name* |
+
+### Tree examples
+
+Leaf number `50`:
+
+```xml
+<formula category="SIZE">
+  <additionalChildren/>
+  <type>NUMBER</type>
+  <value>50</value>
+</formula>
+```
+
+`x + 10`:
+
+```xml
+<formula category="X_POSITION_CHANGE">
+  <additionalChildren/>
+  <leftChild>
+    <additionalChildren/>
+    <type>SENSOR</type>
+    <value>OBJECT_X</value>
+  </leftChild>
+  <rightChild>
+    <additionalChildren/>
+    <type>NUMBER</type>
+    <value>10</value>
+  </rightChild>
+  <type>OPERATOR</type>
+  <value>PLUS</value>
+</formula>
+```
+
+Unary negation `-500` = `MINUS` with no `<leftChild>`. `LOGICAL_NOT` is also unary.
+
+### Three-argument functions use `additionalChildren`
+
+`<additionalChildren>` is present in every node and empty (`<additionalChildren/>`)
+**except** for `JOIN3` and `IF_THEN_ELSE`, where it wraps the third argument in
+fully-qualified `<org.catrobat.catroid.formulaeditor.FormulaElement>` elements:
+
+```xml
+<formula category="X_POSITION">
+  <additionalChildren>
+    <org.catrobat.catroid.formulaeditor.FormulaElement>
+      <additionalChildren/>
+      <type>STRING</type>
+      <value>c</value>
+    </org.catrobat.catroid.formulaeditor.FormulaElement>
+  </additionalChildren>
+  <leftChild>
+    <additionalChildren/>
+    <type>STRING</type>
+    <value>a</value>
+  </leftChild>
+  <rightChild>
+    <additionalChildren/>
+    <type>STRING</type>
+    <value>b</value>
+  </rightChild>
+  <type>FUNCTION</type>
+  <value>JOIN3</value>
+</formula>
+```
+
+For `IF_THEN_ELSE`: `leftChild` = condition, `rightChild` = then-value,
+`additionalChildren[0]` = else-value. Note `<additionalChildren>` comes first
+(alphabetical field order).
+
+## Operators (15)
+
+| Operator | Priority | Type | Meaning |
+|---|---|---|---|
+| `LOGICAL_OR` | 1 | logical | A or B |
+| `LOGICAL_AND` | 2 | logical | A and B |
+| `EQUAL` | 3 | logical | A = B |
+| `NOT_EQUAL` | 4 | logical | A ≠ B |
+| `SMALLER_OR_EQUAL` | 4 | logical | A ≤ B |
+| `GREATER_OR_EQUAL` | 4 | logical | A ≥ B |
+| `SMALLER_THAN` | 4 | logical | A < B |
+| `GREATER_THAN` | 4 | logical | A > B |
+| `LOGICAL_NOT` | 4 | logical | not A (unary) |
+| `PLUS` | 5 | arithmetic | A + B |
+| `MINUS` | 5 | arithmetic | A − B (or unary negation) |
+| `MULT` | 6 | arithmetic | A × B |
+| `DIVIDE` | 6 | arithmetic | A ÷ B |
+| `MOD` | 6 | arithmetic | A mod B |
+| `POW` | 7 | arithmetic | A ^ B |
+
+## Functions (53)
+
+Math: `SIN COS TAN ARCSIN ARCCOS ARCTAN ARCTAN2 LN LOG EXP POWER SQRT ABS
+ROUND FLOOR CEIL MOD MAX MIN RAND PI`
+
+Boolean: `TRUE FALSE IF_THEN_ELSE` (ternary — see additionalChildren above)
+
+String: `LENGTH LETTER SUBTEXT JOIN JOIN3 REGEX CONTAINS`
+
+List: `LIST_ITEM INDEX_OF_ITEM NUMBER_OF_ITEMS FLATTEN`
+
+Touch: `MULTI_FINGER_X MULTI_FINGER_Y MULTI_FINGER_TOUCHED INDEX_CURRENT_TOUCH`
+
+Color/vision: `COLLIDES_WITH_COLOR COLOR_TOUCHES_COLOR COLOR_AT_XY COLOR_EQUALS_COLOR`
+
+Text recognition (ML): `TEXT_BLOCK_X TEXT_BLOCK_Y TEXT_BLOCK_SIZE
+TEXT_BLOCK_FROM_CAMERA TEXT_BLOCK_LANGUAGE_FROM_CAMERA`
+
+Object detection (ML): `ID_OF_DETECTED_OBJECT OBJECT_WITH_ID_VISIBLE`
+
+Hardware: `ARDUINOANALOG ARDUINODIGITAL RASPIDIGITAL`
+
+## Sensors (165)
+
+Sprite/object (apply to the current sprite): `OBJECT_X OBJECT_Y OBJECT_SIZE
+OBJECT_TRANSPARENCY OBJECT_BRIGHTNESS OBJECT_COLOR MOTION_DIRECTION
+LOOK_DIRECTION OBJECT_LAYER OBJECT_DISTANCE_TO OBJECT_LOOK_NUMBER
+OBJECT_LOOK_NAME OBJECT_NUMBER_OF_LOOKS OBJECT_BACKGROUND_NUMBER
+OBJECT_BACKGROUND_NAME OBJECT_X_VELOCITY OBJECT_Y_VELOCITY
+OBJECT_ANGULAR_VELOCITY COLLIDES_WITH_EDGE COLLIDES_WITH_FINGER NFC_TAG_ID
+NFC_TAG_MESSAGE`
+
+Device motion: `X_ACCELERATION Y_ACCELERATION Z_ACCELERATION COMPASS_DIRECTION
+X_INCLINATION Y_INCLINATION LOUDNESS`
+
+Location: `LATITUDE LONGITUDE LOCATION_ACCURACY ALTITUDE`
+
+Time/date: `TIMER DATE_YEAR DATE_MONTH DATE_DAY DATE_WEEKDAY TIME_HOUR
+TIME_MINUTE TIME_SECOND`
+
+Stage: `STAGE_WIDTH STAGE_HEIGHT USER_LANGUAGE`
+
+Touch: `FINGER_X FINGER_Y FINGER_TOUCHED LAST_FINGER_INDEX NUMBER_CURRENT_TOUCHES`
+
+Face detection: `FACE_DETECTED FACE_SIZE FACE_X FACE_Y SECOND_FACE_DETECTED
+SECOND_FACE_SIZE SECOND_FACE_X SECOND_FACE_Y`
+
+Pose detection — each landmark has `_X` and `_Y` sensors (70 total):
+`HEAD_TOP NECK NOSE LEFT_EYE_INNER LEFT_EYE_CENTER LEFT_EYE_OUTER
+RIGHT_EYE_INNER RIGHT_EYE_CENTER RIGHT_EYE_OUTER LEFT_EAR RIGHT_EAR
+MOUTH_LEFT_CORNER MOUTH_RIGHT_CORNER LEFT_SHOULDER RIGHT_SHOULDER LEFT_ELBOW
+RIGHT_ELBOW LEFT_WRIST RIGHT_WRIST LEFT_PINKY RIGHT_PINKY LEFT_INDEX
+RIGHT_INDEX LEFT_THUMB RIGHT_THUMB LEFT_HIP RIGHT_HIP LEFT_KNEE RIGHT_KNEE
+LEFT_ANKLE RIGHT_ANKLE LEFT_HEEL RIGHT_HEEL LEFT_FOOT_INDEX RIGHT_FOOT_INDEX`
+(e.g. `LEFT_WRIST_X`, `LEFT_WRIST_Y`)
+
+Text recognition: `TEXT_FROM_CAMERA TEXT_BLOCKS_NUMBER TEXT_BLOCK_X
+TEXT_BLOCK_Y TEXT_BLOCK_SIZE TEXT_BLOCK_FROM_CAMERA
+TEXT_BLOCK_LANGUAGE_FROM_CAMERA SPEECH_RECOGNITION_LANGUAGE`
+
+Gamepad: `GAMEPAD_A_PRESSED GAMEPAD_B_PRESSED GAMEPAD_UP_PRESSED
+GAMEPAD_DOWN_PRESSED GAMEPAD_LEFT_PRESSED GAMEPAD_RIGHT_PRESSED`
+
+Hardware robots: `NXT_SENSOR_1..4`, `EV3_SENSOR_1..4`,
+`PHIRO_FRONT_LEFT/RIGHT PHIRO_SIDE_LEFT/RIGHT PHIRO_BOTTOM_LEFT/RIGHT`,
+`DRONE_BATTERY_STATUS DRONE_EMERGENCY_STATE DRONE_FLYING DRONE_INITIALIZED
+DRONE_USB_ACTIVE DRONE_USB_REMAINING_TIME DRONE_CAMERA_READY DRONE_RECORD_READY
+DRONE_RECORDING DRONE_NUM_FRAMES`
+
+## BrickField categories
+
+The full set of legal `category` names is the `BrickField` enum (≈130 values
+like `X_POSITION`, `IF_CONDITION`, `TIMES_TO_REPEAT`, `PHIRO_LIGHT_RED`…).
+Per-brick categories are listed in `references/bricks-core.md` and
+`references/bricks-hardware.md` — use only those listed for the brick at hand.

--- a/skills/pocketcode-sprite-xml/references/scripts.md
+++ b/skills/pocketcode-sprite-xml/references/scripts.md
@@ -1,0 +1,72 @@
+# Scripts: event handlers and their XML
+
+The 13 script types, their base structure, per-type extra fields, and the
+script-level `formulaMap`.
+
+## Base structure
+
+```xml
+<script type="ScriptType" posX="0.0" posY="0.0">
+  <brickList>
+    <brick type="...">...</brick>
+  </brickList>
+  <commentedOut>false</commentedOut>
+  <scriptId>uuid-v4</scriptId>
+  <!-- script-type-specific extras, omitted while null -->
+</script>
+```
+
+| Field | Description |
+|---|---|
+| `type` | Script trigger type (table below) — the only legal values |
+| `posX`, `posY` | Editor canvas position, cosmetic — leave unchanged |
+| `brickList` | Ordered bricks to execute (`<brickList/>` when empty) |
+| `commentedOut` | `true` disables the whole script |
+| `scriptId` | UUID — never change; new scripts get a fresh UUID v4 |
+
+## The 13 script types
+
+| `type` | Trigger | Extra XML fields (omitted while null) |
+|---|---|---|
+| `StartScript` | Play button pressed | — |
+| `WhenScript` | Sprite tapped | — |
+| `WhenTouchDownScript` | Stage tapped anywhere | — |
+| `WhenClonedScript` | This sprite starts as a clone | — |
+| `BroadcastScript` | Broadcast message received | `<receivedMessage>` string |
+| `WhenConditionScript` | Formula condition becomes true | `<formulaMap>` (see below) |
+| `WhenBackgroundChangesScript` | Background switches to a look | `<look>` inline or reference into `lookList` |
+| `WhenBounceOffScript` | Bounces off another sprite/edge | `<spriteToBounceOffName>` string (empty element when "") |
+| `WhenGamepadButtonScript` | Cast/gamepad button pressed | `<action>` string |
+| `WhenNfcScript` | NFC tag scanned | `<matchAll>` boolean (default `true` = any tag) + `<nfcTag>` reference when `matchAll=false` |
+| `UserDefinedScript` | Body of a custom brick | `<screenRefresh>` boolean (always present) + `<userDefinedBrickID>` UUID + `<userDefinedBrickInputs>` once linked |
+| `RaspiInterruptScript` | Raspberry Pi GPIO interrupt | `<pin>` and `<eventValue>` strings |
+| `EmptyScript` | Placeholder, no trigger | — |
+
+## Script-level formulas: `formulaMap`, not `formulaList`
+
+A script's own trigger formula uses `<formulaMap>` as a direct child of
+`<script>`, after `<scriptId>`. The inner `<formula category="...">` nodes are
+identical to brick formulas — only the wrapper element differs. Using
+`<formulaList>` on a script fails to import
+("No such field …Script.formulaList").
+
+```xml
+<script type="WhenConditionScript" posX="0.0" posY="0.0">
+  <brickList>...</brickList>
+  <commentedOut>false</commentedOut>
+  <scriptId>uuid</scriptId>
+  <formulaMap>
+    <formula category="IF_CONDITION">
+      <additionalChildren/>
+      <type>NUMBER</type>
+      <value>1</value>
+    </formula>
+  </formulaMap>
+</script>
+```
+
+## Events are scripts, not bricks
+
+The editor shows event headers as bricks (`WhenStartedBrick`,
+`BroadcastReceiverBrick`, `WhenBrick`, …) but those wrapper types never appear
+in serialized `<brickList>`s — the event is the `<script>` element itself.

--- a/skills/pocketcode-sprite-xml/references/sprite-structure.md
+++ b/skills/pocketcode-sprite-xml/references/sprite-structure.md
@@ -1,0 +1,158 @@
+# Sprite structure: `<object>` and its children
+
+The `<object>` element and its asset/data children: looks, sounds, NFC tags,
+variables, lists, XStream references, and sprite-embedding bricks.
+
+## Top level
+
+```xml
+<object type="Sprite" name="SpriteName">
+  <lookList>...</lookList>
+  <soundList/>
+  <scriptList>...</scriptList>
+  <nfcTagList/>
+  <userVariables/>
+  <userLists/>
+  <userDefinedBrickList/>
+</object>
+```
+
+| Field | Description |
+|---|---|
+| `type` | `"Sprite"` normally; `"GroupSprite"` / `"GroupItemSprite"` for editor groups. Legacy `"SingleSprite"` maps to `Sprite` on load. |
+| `name` | Display name of the sprite |
+| children | Always in exactly this order; empty lists as self-closing tags |
+
+## lookList
+
+```xml
+<lookList>
+  <look fileName="1000103316.jpg" name="Man1">
+    <isWebRequest>false</isWebRequest>
+    <valid>true</valid>
+  </look>
+</lookList>
+```
+
+`fileName` = file on disk in the project directory; `name` = editor display
+name (both are XML *attributes*). `isWebRequest` = image came from a URL;
+`valid` = file exists and is usable.
+
+## soundList
+
+Same attribute pattern as looks, one body field:
+
+```xml
+<soundList>
+  <sound fileName="999.mp3" name="Music">
+    <midiFile>false</midiFile>
+  </sound>
+</soundList>
+```
+
+`midiFile` is `true` for synthesized MIDI sounds.
+
+## nfcTagList
+
+```xml
+<nfcTagList>
+  <nfcTag>
+    <name>MyTag</name>
+    <uid>0x04a224ba</uid>
+  </nfcTag>
+</nfcTagList>
+```
+
+Usually `<nfcTagList/>`. Referenced by `WhenNfcScript` when `matchAll` is `false`.
+
+## userVariable (in bricks and at sprite level)
+
+`UserVariable` uses a custom converter — note the wrapper attributes and
+`<default>` nesting:
+
+```xml
+<userVariable type="UserVariable" serialization="custom">
+  <userVariable>
+    <default>
+      <initialIndex>-1</initialIndex>
+      <deviceValueKey>uuid</deviceValueKey>
+      <name>variableName</name>
+    </default>
+  </userVariable>
+</userVariable>
+```
+
+A legacy form without the `type` attribute (just the name as text) still
+parses, but never generate it.
+
+## userList (in bricks and at sprite level)
+
+`UserList` is **plain** — different shape than `UserVariable`:
+
+```xml
+<userList>
+  <deviceListKey>uuid</deviceListKey>
+  <initialIndex>-1</initialIndex>
+  <name>listName</name>
+</userList>
+```
+
+Key is `deviceListKey` (not `deviceValueKey`); no custom wrapper, no `<default>`.
+
+## Sprite-level userVariables / userLists
+
+Because `scriptList` serializes before `userVariables`, a variable already
+inlined inside a brick appears at sprite level as a **reference back into the
+script** — this is normal output, don't "fix" it:
+
+```xml
+<userVariables>
+  <userVariable reference="../../scriptList/script/brickList/brick/userVariable"/>
+</userVariables>
+```
+
+## XStream references
+
+Relative XPath-style `reference` attributes avoid duplicating objects. `[n]`
+indices are 1-based; a tag name without an index means the first match.
+
+```xml
+<look reference="../../../../../lookList/look"/>
+<userVariable reference="../../brick[2]/userVariable"/>
+```
+
+**Rule:** preserve `reference` attributes exactly. Inline a full block only at
+the first occurrence of the object, or when the brick is new.
+
+## Sprite-reference bricks embed the whole target sprite
+
+`PointToBrick` (`pointedObject`), `GoToBrick` (`destinationSprite`), and
+`CloneBrick` (`objectToClone`) hold plain sprite fields. In standalone sprite
+XML the **entire target sprite is inlined**:
+
+```xml
+<brick type="PointToBrick">
+  <brickId>uuid</brickId>
+  <commentedOut>false</commentedOut>
+  <pointedObject type="Sprite" name="Enemy">
+    <lookList/>
+    <soundList/>
+    <scriptList/>
+    <nfcTagList/>
+    <userVariables/>
+    <userLists/>
+    <userDefinedBrickList/>
+  </pointedObject>
+</brick>
+```
+
+A second brick referencing the same sprite gets a reference:
+
+```xml
+<objectToClone reference="../../brick[4]/pointedObject"/>
+```
+
+When generating: omit the sprite field (`CloneBrick` then clones itself;
+`GoToBrick` uses `<spinnerSelection>`: 80 = touch position, 81 = random
+position, 82 = other sprite) or preserve the existing reference/inline block.
+Never invent a nested sprite.


### PR DESCRIPTION
## Summary

Adds a Pocket Code sprite XML skill and supporting reference documentation for AI Tutor.

The skill provides an authoritative reference for generating, editing, and validating Pocket Code sprite XML that is compatible with the Catroid serializer and validator pipeline.

## Changes

* Add `skills/pocketcode-sprite-xml/SKILL.md`
* Add detailed reference documentation under `references/`
* Document sprite structure, scripts, bricks, formulas, and composite brick rules
* Document common validation and parsing failure cases
* Add import-verified XML examples and implementation references