### PR TITLE
Add typed onError callback and route launch errors through it

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Scaffold(
             // The AI's answer copied back from the external app — validate/apply it.
             applyAiResult(pastedText)
         },
+        onError = { error ->
+            // error.type: AiTutorErrorType, error.message: localized String
+            Toast.makeText(context, error.message, Toast.LENGTH_LONG).show()
+        },
       )
 }
 ```
@@ -63,6 +67,7 @@ Scaffold(
 - `outputContext` → optional, send extra info (like compiler errors) to help the AI provide better answers.
 - `systemContext` → optional, provide additional context, such as the programming language, version, or framework being used.
 - `onClipboardPaste` → optional, enables the paste-back flow. When provided, the tutor shows a "Paste AI Answer" dialog after the user returns from the AI app and delivers the clipboard text to this callback.
+- `onError` → optional, invoked when the tutor hits a recoverable error (failed to load AI apps, empty-clipboard paste, or an app-launch problem). It receives an `AiTutorError` with a `type` (`AiTutorErrorType`) and a localized `message`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Scaffold(
             applyAiResult(pastedText)
         },
         onError = { error ->
-            // error.type: AiTutorErrorType, error.message: localized String
             Toast.makeText(context, error.message, Toast.LENGTH_LONG).show()
         },
       )

--- a/shared/src/androidMain/kotlin/org/catrobat/aitutor/ui/AiAppLauncher.kt
+++ b/shared/src/androidMain/kotlin/org/catrobat/aitutor/ui/AiAppLauncher.kt
@@ -3,8 +3,10 @@ package org.catrobat.aitutor.ui
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
-import android.widget.Toast
 import kotlinx.coroutines.runBlocking
+import org.catrobat.aitutor.domain.model.AiTutorError
+import org.catrobat.aitutor.domain.model.AiTutorErrorType
+import org.catrobat.aitutor.domain.model.LaunchResult
 import org.catrobat.shared.generated.resources.Res
 import org.catrobat.shared.generated.resources.could_not_launch_this_app
 import org.catrobat.shared.generated.resources.could_not_send_prompt_directly
@@ -16,7 +18,7 @@ actual class AiAppLauncher(private val context: Context) {
     actual suspend fun launchApp(
         prompt: String,
         packageName: String?,
-    ) {
+    ): LaunchResult {
         try {
             val sendIntent =
                 Intent().apply {
@@ -38,31 +40,35 @@ actual class AiAppLauncher(private val context: Context) {
                 }
             chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             context.startActivity(chooserIntent)
+            return LaunchResult.Success
         } catch (e: ActivityNotFoundException) {
             // Fallback for apps that don't handle ACTION_SEND
             if (packageName != null) {
                 val launchIntent = context.packageManager.getLaunchIntentForPackage(packageName)
-                if (launchIntent != null) {
+                return if (launchIntent != null) {
                     context.startActivity(launchIntent)
                     // You should probably copy the prompt to the clipboard here as well.
-                    Toast.makeText(
-                        context,
-                        getString(Res.string.could_not_send_prompt_directly),
-                        Toast.LENGTH_LONG,
-                    ).show()
+                    LaunchResult.Error(
+                        AiTutorError(
+                            type = AiTutorErrorType.PROMPT_NOT_SENT_DIRECTLY,
+                            message = getString(Res.string.could_not_send_prompt_directly),
+                        ),
+                    )
                 } else {
-                    Toast.makeText(
-                        context,
-                        getString(Res.string.could_not_launch_this_app),
-                        Toast.LENGTH_SHORT,
-                    ).show()
+                    LaunchResult.Error(
+                        AiTutorError(
+                            type = AiTutorErrorType.COULD_NOT_LAUNCH_APP,
+                            message = getString(Res.string.could_not_launch_this_app),
+                        ),
+                    )
                 }
             } else {
-                Toast.makeText(
-                    context,
-                    getString(Res.string.no_app_found_to_handle_this_action),
-                    Toast.LENGTH_SHORT,
-                ).show()
+                return LaunchResult.Error(
+                    AiTutorError(
+                        type = AiTutorErrorType.NO_APP_FOUND,
+                        message = getString(Res.string.no_app_found_to_handle_this_action),
+                    ),
+                )
             }
         }
     }

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -58,4 +58,5 @@
     <string name="paste_answer_title">Paste AI Answer</string>
     <string name="paste_answer_description">If you've copied the AI's answer, tap Paste below to apply it. If not, tap Cancel to continue your work.</string>
     <string name="paste_from_clipboard">Paste from Clipboard</string>
+    <string name="paste_answer_error_no_text_found">No text found in clipboard. Please copy the AI's answer first.</string>
 </resources>

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/domain/model/AiTutorError.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/domain/model/AiTutorError.kt
@@ -1,0 +1,14 @@
+package org.catrobat.aitutor.domain.model
+
+enum class AiTutorErrorType {
+    LOADING_INSTALLED_APPS,
+    CLIPBOARD_PASTE,
+    NO_APP_FOUND,
+    COULD_NOT_LAUNCH_APP,
+    PROMPT_NOT_SENT_DIRECTLY,
+}
+
+data class AiTutorError(
+    val type: AiTutorErrorType,
+    val message: String,
+)

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/domain/model/LaunchResult.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/domain/model/LaunchResult.kt
@@ -1,0 +1,7 @@
+package org.catrobat.aitutor.domain.model
+
+sealed interface LaunchResult {
+    data object Success : LaunchResult
+
+    data class Error(val error: AiTutorError) : LaunchResult
+}

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/AiAppLauncher.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/AiAppLauncher.kt
@@ -1,8 +1,10 @@
 package org.catrobat.aitutor.ui
 
+import org.catrobat.aitutor.domain.model.LaunchResult
+
 expect class AiAppLauncher {
     suspend fun launchApp(
         prompt: String,
         packageName: String? = null,
-    )
+    ): LaunchResult
 }

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/ClipboardPasteView.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/components/ClipboardPasteView.kt
@@ -33,6 +33,7 @@ import org.catrobat.aitutor.util.getText
 import org.catrobat.shared.generated.resources.Res
 import org.catrobat.shared.generated.resources.cancel
 import org.catrobat.shared.generated.resources.paste_answer_description
+import org.catrobat.shared.generated.resources.paste_answer_error_no_text_found
 import org.catrobat.shared.generated.resources.paste_answer_title
 import org.catrobat.shared.generated.resources.paste_from_clipboard
 import org.jetbrains.compose.resources.stringResource
@@ -42,9 +43,11 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 internal fun ClipboardPasteView(
     onPasteResult: (String) -> Unit,
     onDismissRequest: () -> Unit,
+    onClipboardPasteError: (String) -> Unit,
 ) {
     val clipboard = LocalClipboard.current
     val scope = rememberCoroutineScope()
+    val noTextFoundError = stringResource(Res.string.paste_answer_error_no_text_found)
     ClipboardPasteViewContent(
         title = stringResource(Res.string.paste_answer_title),
         description = stringResource(Res.string.paste_answer_description),
@@ -53,7 +56,11 @@ internal fun ClipboardPasteView(
         onPaste = {
             scope.launch {
                 val text = clipboard.getClipEntry()?.getText()
-                if (!text.isNullOrBlank()) onPasteResult(text)
+                if (!text.isNullOrBlank()) {
+                    onPasteResult(text)
+                } else {
+                    onClipboardPasteError(noTextFoundError)
+                }
             }
         },
         onDismissRequest = onDismissRequest,

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/public/AiTutorView.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/public/AiTutorView.kt
@@ -10,6 +10,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import org.catrobat.aitutor.di.AiTutorKoin
+import org.catrobat.aitutor.domain.model.AiTutorError
+import org.catrobat.aitutor.domain.model.AiTutorErrorType
 import org.catrobat.aitutor.ui.TutorUiStep
 import org.catrobat.aitutor.ui.components.AboutScreen
 import org.catrobat.aitutor.ui.components.AppChooserView
@@ -79,6 +81,20 @@ private val aiTutorViewModelFactory =
  * reads the clipboard and delivers its text to this callback, then dismisses the view. Tapping
  * Cancel dismisses without invoking the callback. When `null` (the default), the view dismisses
  * immediately after the user selects an AI app, preserving the original behavior.
+ * @param onError An optional callback invoked when the AI Tutor encounters a recoverable error,
+ * such as failing to load the installed AI apps, attempting to paste an empty clipboard, or
+ * failing to launch the selected AI app. It receives an [AiTutorError] carrying both a
+ * [AiTutorErrorType] and a localized message the host app can surface (e.g. as a toast or
+ * snackbar), e.g.:
+ * ```
+ * onError = { error ->
+ *     when (error.type) {
+ *         AiTutorErrorType.CLIPBOARD_PASTE -> showToast(error.message)
+ *         else -> showToast(error.message)
+ *     }
+ * }
+ * ```
+ * The view stays open so the user can retry. When `null` (the default), errors are ignored.
  */
 @Composable
 fun AiTutorView(
@@ -89,9 +105,16 @@ fun AiTutorView(
     outputContext: String? = null,
     systemContext: String? = null,
     onClipboardPaste: ((pastedText: String) -> Unit)? = null,
+    onError: ((error: AiTutorError) -> Unit)? = null,
 ) {
     val viewModel: AiTutorViewModel = viewModel(factory = aiTutorViewModelFactory)
     val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.errors.collect { error ->
+            onError?.invoke(error)
+        }
+    }
 
     LaunchedEffect(show, outputContext) {
         if (show) {
@@ -170,6 +193,14 @@ fun AiTutorView(
                 onDismissRequest = {
                     viewModel.resetPasteStep()
                     onDismissRequest()
+                },
+                onClipboardPasteError = { message ->
+                    viewModel.emitError(
+                        AiTutorError(
+                            type = AiTutorErrorType.CLIPBOARD_PASTE,
+                            message = message,
+                        ),
+                    )
                 },
             )
         }

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/viewmodel/AiTutorViewModel.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/ui/viewmodel/AiTutorViewModel.kt
@@ -2,16 +2,19 @@ package org.catrobat.aitutor.ui.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.catrobat.aitutor.domain.model.AiTutorError
+import org.catrobat.aitutor.domain.model.AiTutorErrorType
+import org.catrobat.aitutor.domain.model.LaunchResult
 import org.catrobat.aitutor.domain.prompt.PromptVersion
 import org.catrobat.aitutor.domain.usecase.CreateShareablePromptUseCase
 import org.catrobat.aitutor.domain.usecase.GetInstalledAiAppsUseCase
@@ -34,8 +37,8 @@ class AiTutorViewModel(
     private val _uiState = MutableStateFlow(AiTutorUiState())
     val uiState: StateFlow<AiTutorUiState> = _uiState.asStateFlow()
 
-    private val _errorMessageFlow = MutableSharedFlow<String>()
-    val errorMessageFlow: SharedFlow<String> = _errorMessageFlow.asSharedFlow()
+    private val _errors = Channel<AiTutorError>(Channel.BUFFERED)
+    val errors: Flow<AiTutorError> = _errors.receiveAsFlow()
 
     init {
         loadInstalledApps()
@@ -94,6 +97,12 @@ class AiTutorViewModel(
         _uiState.update { it.copy(currentStep = TutorUiStep.Hidden) }
     }
 
+    fun emitError(error: AiTutorError) {
+        viewModelScope.launch {
+            _errors.send(error)
+        }
+    }
+
     fun onCurrentStepChanged(newStep: TutorUiStep) {
         viewModelScope.launch {
             // Delay so the paste dialog doesn't appear immediately over the launching AI app.
@@ -140,7 +149,10 @@ class AiTutorViewModel(
                 systemContext = systemContext,
             )
         viewModelScope.launch {
-            aiAppLauncher.launchApp(finalPrompt, packageName)
+            when (val result = aiAppLauncher.launchApp(finalPrompt, packageName)) {
+                is LaunchResult.Error -> _errors.send(result.error)
+                LaunchResult.Success -> Unit
+            }
         }
     }
 
@@ -152,10 +164,14 @@ class AiTutorViewModel(
                 _uiState.update { it.copy(installedApps = apps, isLoading = false) }
             } catch (e: Exception) {
                 _uiState.update { it.copy(isLoading = false) }
-                _errorMessageFlow.emit(
-                    getString(
-                        Res.string.error_loading_installed_ai_apps,
-                        e.message ?: "",
+                _errors.send(
+                    AiTutorError(
+                        type = AiTutorErrorType.LOADING_INSTALLED_APPS,
+                        message =
+                            getString(
+                                Res.string.error_loading_installed_ai_apps,
+                                e.message ?: "",
+                            ),
                     ),
                 )
             }

--- a/shared/src/iosMain/kotlin/org/catrobat/aitutor/ui/AiAppLauncher.kt
+++ b/shared/src/iosMain/kotlin/org/catrobat/aitutor/ui/AiAppLauncher.kt
@@ -1,10 +1,12 @@
 package org.catrobat.aitutor.ui
 
+import org.catrobat.aitutor.domain.model.LaunchResult
+
 actual class AiAppLauncher {
     actual suspend fun launchApp(
         prompt: String,
         packageName: String?,
-    ) {
+    ): LaunchResult {
         TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
## Summary

Stacked on top of [`clipboard-support` branch](https://github.com/Catrobat/catrobat-ai-tutor/pull/21). Replaces the library's internal `Toast`s and string-only error reporting with a **typed `onError`** callback on `AiTutorView`, so host apps own all user-facing messaging.

The host now receives an `AiTutorError` carrying both a `type` (`AiTutorErrorType`) and a localized `message`, letting it react differently per error source (toast vs. retry banner, etc.).

## Changes

- **New domain models:** `AiTutorError(type, message)` + `AiTutorErrorType` enum, and a sealed `LaunchResult` (`Success` / `Error`).
- **`AiAppLauncher.launchApp`** returns `LaunchResult` instead of showing `Toast`s — removes the library's only `Toast` usage. The "launched but prompt not auto-sent" warning is modeled explicitly rather than as a hard failure.
- **`AiTutorView`** exposes `onError: ((AiTutorError) -> Unit)?` and collects all errors from one place.
- **Single error funnel:** app-load failures, empty-clipboard paste, and all three launch outcomes flow through a `Channel`-backed flow (delivered once, no stale re-fire on recomposition).
- **README** documents `onError`.

## Breaking changes

- `AiAppLauncher.launchApp` now returns `LaunchResult` (internal wiring; not part of the host-facing API).