### PR TITLE
Relocate embedded Koin to org.catrobat.aitutor.internal.koin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "koin-embedded"]
+	path = koin-embedded
+	url = https://github.com/InsertKoinIO/koin-embedded.git

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,8 +36,8 @@ compose-material3 = { module = "androidx.compose.material3:material3", version.r
 androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle-viewModel" }
-embedded-koin-core = { module = "io.insert-koin:embedded-koin-core", version.ref = "embedded-koin" }
-embedded-koin-android = { module = "io.insert-koin:embedded-koin-android", version.ref = "embedded-koin" }
+embedded-koin-core = { module = "io.insert-koin:aitutor-koin-core", version.ref = "embedded-koin" }
+embedded-koin-android = { module = "io.insert-koin:aitutor-koin-android", version.ref = "embedded-koin" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
 coil3-coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coilNetworkOkhttp" }
 aboutlibraries-core = { module = "com.mikepenz:aboutlibraries-core", version.ref = "aboutLibraries" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,10 +11,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven {
-            name = "kotzilla"
-            url = uri("https://repository.kotzilla.io/repository/Koin-Embedded/")
-        }
+        mavenLocal()
     }
 }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -76,7 +76,7 @@ kotlin {
             implementation(libs.viewmodel.compose)
 
             // Koin
-            api(libs.embedded.koin.core)
+            implementation(libs.embedded.koin.core)
 
             // Datastore
             implementation(libs.androidx.datastore)

--- a/shared/src/androidMain/kotlin/org/catrobat/aitutor/AiTutorStartupInitializer.kt
+++ b/shared/src/androidMain/kotlin/org/catrobat/aitutor/AiTutorStartupInitializer.kt
@@ -2,13 +2,13 @@ package org.catrobat.aitutor
 
 import android.content.Context
 import androidx.startup.Initializer
-import embedded.koin.android.ext.koin.androidContext
-import embedded.koin.android.ext.koin.androidLogger
-import embedded.koin.core.logger.Level
-import embedded.koin.dsl.koinApplication
 import org.catrobat.aitutor.di.AiTutorKoin
 import org.catrobat.aitutor.di.commonModule
 import org.catrobat.aitutor.di.platformModule
+import org.catrobat.aitutor.internal.koin.android.ext.koin.androidContext
+import org.catrobat.aitutor.internal.koin.android.ext.koin.androidLogger
+import org.catrobat.aitutor.internal.koin.core.logger.Level
+import org.catrobat.aitutor.internal.koin.dsl.koinApplication
 
 class AiTutorStartupInitializer : Initializer<Unit> {
     override fun create(context: Context) {

--- a/shared/src/androidMain/kotlin/org/catrobat/aitutor/di/PlatformModule.android.kt
+++ b/shared/src/androidMain/kotlin/org/catrobat/aitutor/di/PlatformModule.android.kt
@@ -5,12 +5,12 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
-import embedded.koin.android.ext.koin.androidContext
-import embedded.koin.core.module.Module
-import embedded.koin.dsl.module
 import org.catrobat.aitutor.data.AndroidAiAppRepository
 import org.catrobat.aitutor.data.InstalledAiAppDataSource
 import org.catrobat.aitutor.domain.repository.AiAppRepository
+import org.catrobat.aitutor.internal.koin.android.ext.koin.androidContext
+import org.catrobat.aitutor.internal.koin.core.module.Module
+import org.catrobat.aitutor.internal.koin.dsl.module
 import org.catrobat.aitutor.ui.AiAppLauncher
 
 actual fun platformModule(): Module =

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/di/AiTutorKoin.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/di/AiTutorKoin.kt
@@ -1,6 +1,6 @@
 package org.catrobat.aitutor.di
 
-import embedded.koin.core.KoinApplication
+import org.catrobat.aitutor.internal.koin.core.KoinApplication
 import kotlin.concurrent.Volatile
 
 internal object AiTutorKoin {

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/di/CommonModule.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/di/CommonModule.kt
@@ -1,7 +1,5 @@
 package org.catrobat.aitutor.di
 
-import embedded.koin.core.module.dsl.factoryOf
-import embedded.koin.dsl.module
 import org.catrobat.aitutor.data.ComposeResourcePromptTemplateRepository
 import org.catrobat.aitutor.data.DataStoreSettingsRepository
 import org.catrobat.aitutor.domain.repository.PromptTemplateRepository
@@ -10,6 +8,8 @@ import org.catrobat.aitutor.domain.usecase.CreateShareablePromptUseCase
 import org.catrobat.aitutor.domain.usecase.GetInstalledAiAppsUseCase
 import org.catrobat.aitutor.domain.usecase.GetTutorialSeenStateUseCase
 import org.catrobat.aitutor.domain.usecase.SetTutorialSeenUseCase
+import org.catrobat.aitutor.internal.koin.core.module.dsl.factoryOf
+import org.catrobat.aitutor.internal.koin.dsl.module
 import org.catrobat.aitutor.ui.viewmodel.AiTutorViewModel
 
 val commonModule =

--- a/shared/src/commonMain/kotlin/org/catrobat/aitutor/di/PlatformModule.kt
+++ b/shared/src/commonMain/kotlin/org/catrobat/aitutor/di/PlatformModule.kt
@@ -1,6 +1,6 @@
 package org.catrobat.aitutor.di
 
-import embedded.koin.core.module.Module
+import org.catrobat.aitutor.internal.koin.core.module.Module
 
 expect fun platformModule(): Module
 

--- a/shared/src/iosMain/kotlin/org/catrobat/aitutor/di/PlatformModule.ios.kt
+++ b/shared/src/iosMain/kotlin/org/catrobat/aitutor/di/PlatformModule.ios.kt
@@ -1,6 +1,6 @@
 package org.catrobat.aitutor.di
 
-import embedded.koin.core.module.Module
+import org.catrobat.aitutor.internal.koin.core.module.Module
 
 actual fun platformModule(): Module {
     TODO("Not yet implemented")


### PR DESCRIPTION
## Summary

This PR implements #18, which is to implement Custom Relocation https://insert-koin.io/docs/support/embedded/#custom-relocation-beta. This implementation still has problems on the setup side because of inconsistencies between the koin docs, the embedded koin repo README.md and the shell scripts themselves. Here are the problems:

### 1. In the koin docs it says that we can use company package name:

> Example custom relocation:
> 
> org.koin.* → com.acme.sdk.internal.koin.*

And also the steps:

> Configure your custom package name in the relocation script
> Run the relocation process:
> 
> ```
> ./scripts/relocate.sh com.acme.sdk.internal.koin
> ```

But in reality, we have to configure `relocate.properties` first to set our custom package name, but there is no `scripts/` folder at all, all the scripts (relocate.sh, clone_koin.sh, relocate-packages.sh, relocate-module.sh) are in the root of the repo. And the prefix in the properties should not include the `.koin` part, because the script appends it by itself:

```
TARGET_PACKAGE="$RELOCATION_PREFIX.koin"
```

so if we follow the docs example as the prefix, we would get `com.acme.sdk.internal.koin.koin.*`

And it has another problem, which is the second one

### 2. relocate.sh doesn't read the argument

So the idea of using `./scripts/relocate.sh org.catrobat.aitutor.internal.koin` is not valid since it is not used. It is used in `relocate-packages.sh`, but passed as `relocate.properties`'s `$RELOCATION_PREFIX` that `relocate.sh` reads.

And the bad part is that it doesn't error, it just exits 0 and uses whatever is inside relocate.properties (`relocated` by default), so we can get a "success" build but with the wrong package name and not notice it.

### 3. The documented package name example cannot work

So when using org.catrobat.aitutor.internal as the RELOCATION_PREFIX, I got this error when building:

```
* What went wrong:
org.gradle.api.InvalidUserDataException: Cannot generate project dependency accessors:
  - Cannot generate project dependency accessors because project
    'org.catrobat.aitutor.internal-koin-core' doesn't follow the naming convention:
    [a-zA-Z]([A-Za-z0-9\-_])*
  - ... (one per module)
```

In the readme they use "relocated" as the sample, which doesn't have a dot, so maybe the documented sample is not tested here 😅

So that's the current problem, so we have to do a little workaround for the setup

#### 1. Not using a dotted package name for the RELOCATION_PREFIX in relocate.properties

This is the easiest setup, but it doesn't fulfill our needs, which is to use our org package name

#### 2. Add a new property ARTIFACT_PREFIX for the dotted workaround

I added a new value:
```
ARTIFACT_PREFIX=aitutor
```

then separated the package naming from the artifact naming:
```
cd koin-embedded
sed -i 's|\$RELOCATION_PREFIX/\$RELOCATION_PREFIX-|$ARTIFACT_PREFIX/$ARTIFACT_PREFIX-|; s|insert-koin/\$RELOCATION_PREFIX|insert-koin/$ARTIFACT_PREFIX|' relocate.sh
grep -n 'ARTIFACT_PREFIX' relocate.sh
```

then:
```
./relocate.sh
```

I use this second approach to make the package name as we want.

## Changes

- Added `koin-embedded` as a git submodule
- `settings.gradle.kts` - removed the kotzilla maven repo, use `mavenLocal()` instead
- `gradle/libs.versions.toml` - point the koin modules to `io.insert-koin:aitutor-koin-core` and `io.insert-koin:aitutor-koin-android`
- Changed all the `embedded.koin.*` imports to `org.catrobat.aitutor.internal.koin.*` (6 files in `shared/src`)

Notes:

- the `relocate.properties` and the `relocate.sh` edits are only local for now, the submodule only records the upstream commit. So for now, anyone who wants to rebuild koin has to do the workaround steps I explained above manually
- because we use `mavenLocal()`, the CI and anyone building this from source has to run the relocation first.
